### PR TITLE
fix error in rts2fits document

### DIFF
--- a/doc/rts2fits.txt
+++ b/doc/rts2fits.txt
@@ -12,7 +12,7 @@ JD	d	JD, is equal (in date sense) to CTIME+USEC/10^6
 EPOCH_ID	l	RTS2 epoch of observation (1, 2, 3, - currently must be number..)
 TARGET	l	RTS2 target id, which selector suplied to executor
 TARSEL	l	RTS2 target id, which executor choosed (e.g. is 22xx on FRAM, when TARGET is 6; a bit misleading anyway, I think I have to swap that two values)
-TARTYPE	c	RTS2 target type; see src/utilsdb/target.h for list
+TARTYPE	c	RTS2 target type; see include/rts2db/target.h for list
 OBSID	l	RTS2 observation ID
 IMGID	l	RTS2 image ID; counts from 1 to infiniti for given OBSERVATION, for new observation, count is reseted
 PROCES	l	mistage, needs to be removed; should be called PROC


### PR DESCRIPTION
USEC is given by tv.usec, so its unit should be microseconds.
