### PR TITLE
Add OpenSSL support for XMLRPC server

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,14 @@ AC_TYPE_SIZE_T
 AC_HEADER_TIME
 AC_STRUCT_TM
 
+AC_ARG_ENABLE(ssl,
+[  --enable-ssl            enable openssl encryption in httpd],
+[case "${enableval}" in
+	yes) ssl=yes ;;
+	no)  ssl=no ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-ssl) ;;
+esac],[ssl=no])
+
 AC_ARG_ENABLE(focusing,
 [  --disable-focusing      disables focusing in camd (=>camd doesn't need cfitsio to build)],
 [case "${enableval}" in
@@ -541,6 +549,16 @@ AC_SUBST(CENTRALD_PORT)
 
 # Checks for libraries.
 
+AH_TEMPLATE([SSL], [using openssl in httpd])
+if test "x${ssl}" != "xno"; then
+  PKG_CHECK_MODULES(SSL, [openssl >= 1.0.1],,AC_MSG_RESULT(not found))
+fi
+AM_CONDITIONAL(SSL, test "x$SSL_LIBS" != x)
+if test "x$SSL_LIBS" != x; then
+  AC_DEFINE_UNQUOTED(SSL, "1", [using openssl in httpd])
+fi
+
+
 if test "x${cfitsio}" != "xno"; then
   if test "x${cfitsio}" != "xyes"; then
     LDFLAGS="${LDFLAGS} -L${cfitsio}"
@@ -961,6 +979,7 @@ echo "
   libarchive    ${libarchive}
   crypt         ${LIB_CRYPT}
   libgjson	${JSONGLIB_CFLAGS} ${JSONGLIB_LIBS}
+  openssl       ${ssl}
 
 CCDs:
   alta          ${ALTA}

--- a/include/xmlrpc++/Makefile.am
+++ b/include/xmlrpc++/Makefile.am
@@ -10,6 +10,7 @@ noinst_HEADERS = \
 	XmlRpcServerMethod.h \
 	XmlRpcServerGetRequest.h \
 	XmlRpcSocket.h \
+	XmlRpcSocketSSL.h \
 	XmlRpcSource.h \
 	XmlRpcUtil.h \
 	XmlRpcValue.h

--- a/include/xmlrpc++/XmlRpcServer.h
+++ b/include/xmlrpc++/XmlRpcServer.h
@@ -14,9 +14,18 @@
 # include <string>
 #endif
 
+#include "rts2-config.h"
+
 #include "XmlRpcDispatch.h"
-#include "XmlRpcSocket.h"
+
+#ifdef RTS2_SSL
+# include "XmlRpcSocketSSL.h"
+#else
+# include "XmlRpcSocket.h"
+#endif
+
 #include "XmlRpcSource.h"
+
 
 namespace XmlRpc
 {
@@ -42,8 +51,13 @@ namespace XmlRpc
 		public:
 			//! Create a server object.
 			XmlRpcServer();
+
 			//! Destructor.
 			virtual ~XmlRpcServer();
+
+#ifdef RTS2_SSL
+		    int initSSL(const char *certFile, const char *keyFile);
+#endif
 
 			//! Specify whether introspection is enabled or not. Default is not enabled.
 			void enableIntrospection(bool enabled=true);

--- a/include/xmlrpc++/XmlRpcSocketSSL.h
+++ b/include/xmlrpc++/XmlRpcSocketSSL.h
@@ -1,0 +1,103 @@
+#ifndef _XMLRPCSOCKET_H_
+#define _XMLRPCSOCKET_H_
+//
+// XmlRpc++ Copyright (c) 2002-2003 by Chris Morley
+//
+#if defined(_MSC_VER)
+# pragma warning(disable:4786)	 // identifier was truncated in debug info
+#endif
+
+#ifndef MAKEDEPEND
+# include <string>
+#endif
+
+#include <map>
+
+#ifdef _WINDOWS
+#include <winsock2.h>
+#else
+extern "C"
+{
+	#include <sys/types.h>
+	#include <netdb.h>
+	#include <netinet/in.h>
+}
+#endif
+
+// OpenSSL
+#include "openssl/bio.h"
+#include "openssl/ssl.h"
+#include "openssl/err.h"
+
+namespace XmlRpc
+{
+
+	//! A platform-independent socket API.
+	class XmlRpcSocket
+	{
+		public:
+
+			//! Creates a stream (TCP) socket. Returns -1 on failure.
+			static int socket();
+
+			//! Closes a socket.
+			static void close(int socket);
+
+			//! Sets a stream (TCP) socket to perform non-blocking IO. Returns false on failure.
+			static bool setNonBlocking(int socket);
+
+			//! unSets a stream (TCP) socket to perform blocking IO. Returns false on failure.
+			static bool unsetNonBlocking(int socket);
+
+			//! Read text from the specified socket. Returns false on error.
+			static bool nbRead(int socket, char* &s, int &l, bool *eof);
+
+			//! Write text to the specified socket. Returns false on error.
+			static size_t nbWrite(int socket, std::string s, size_t *bytesSoFar, bool sendfull = true);
+
+			//! Write buffer to the specified socket. Returns false on error.
+			static size_t nbWriteBuf(int socket, const char *buf, size_t buf_len, size_t *bytesSoFar, bool sendfull = true, bool retry = true);
+
+			// The next four methods are appropriate for servers.
+
+			//! Allow the port the specified socket is bound to to be re-bound immediately 
+			//! server re-starts are not delayed. Returns false on failure.
+			static bool setReuseAddr(int socket);
+
+			//! Bind to a specified port
+			static bool bind(int socket, int port);
+
+			//! Set socket in listen mode
+			static bool listen(int socket, int backlog);
+
+			//! Accept a client connection request
+#ifdef _WINDOWS
+			static int accept(int socket, struct sockaddr_in &addr, int &addrlen);
+#else
+			static int accept(int socket, struct sockaddr_in &addr, socklen_t &addrlen);
+#endif
+
+			//! Connect a socket to a server (from a client)
+			static bool connect(int socket, std::string& host, int port);
+
+			//! Returns last errno
+			static int getError();
+
+			//! Returns message corresponding to last error
+			static std::string getErrorMsg();
+
+			//! Returns message corresponding to error
+			static std::string getErrorMsg(int error);
+
+			//! Initialize OpenSSL Context
+			static int initSSL(const char *certFile, const char *keyFile);
+
+			//! OpenSSL Context
+			static SSL_CTX *ctx;
+
+			//! SSL object map
+			static std::map<int, SSL*> ssl_map;
+	};
+
+}								 // namespace XmlRpc
+#endif

--- a/lib/xmlrpc++/Makefile.am
+++ b/lib/xmlrpc++/Makefile.am
@@ -8,9 +8,21 @@ librts2xmlrpc_la_SOURCES = \
 	XmlRpcServer.cpp \
 	XmlRpcServerMethod.cpp \
 	XmlRpcServerGetRequest.cpp \
-	XmlRpcSocket.cpp \
 	XmlRpcSource.cpp \
 	XmlRpcUtil.cpp \
 	XmlRpcValue.cpp
 
 librts2xmlrpc_la_CXXFLAGS = @NOVA_CFLAGS@ -I../../include -I../../include/xmlrpc++
+
+if SSL
+
+librts2xmlrpc_la_SOURCES += XmlRpcSocketSSL.cpp
+librts2xmlrpc_la_LIBADD = @SSL_LIBS@
+EXTRA_DIST = XmlRpcSocket.cpp
+
+else
+
+librts2xmlrpc_la_SOURCES += XmlRpcSocket.cpp
+EXTRA_DIST = XmlRpcSocketSSL.cpp
+
+endif

--- a/lib/xmlrpc++/XmlRpcServer.cpp
+++ b/lib/xmlrpc++/XmlRpcServer.cpp
@@ -12,6 +12,13 @@ extern "C" {
 
 using namespace XmlRpc;
 
+#ifdef RTS2_SSL
+int XmlRpcServer::initSSL(const char *certFile, const char *keyFile)
+{
+	return XmlRpcSocket::initSSL(certFile, keyFile);
+}
+#endif
+
 XmlRpcServer::XmlRpcServer()
 {
 	_introspectionEnabled = false;

--- a/lib/xmlrpc++/XmlRpcSocketSSL.cpp
+++ b/lib/xmlrpc++/XmlRpcSocketSSL.cpp
@@ -1,0 +1,344 @@
+
+#include "XmlRpcSocketSSL.h"
+#include "XmlRpcUtil.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <iostream>
+
+// OpenSSL
+#include "openssl/bio.h"
+#include "openssl/ssl.h"
+#include "openssl/err.h"
+
+#ifndef MAKEDEPEND
+
+#if defined(_WINDOWS)
+# include <stdio.h>
+# include <winsock2.h>
+//# pragma lib(WS2_32.lib)
+
+# define EINPROGRESS  WSAEINPROGRESS
+# define EWOULDBLOCK  WSAEWOULDBLOCK
+# define ETIMEDOUT      WSAETIMEDOUT
+#else
+extern "C"
+{
+	# include <unistd.h>
+	# include <stdio.h>
+	# include <sys/types.h>
+	# include <netdb.h>
+	# include <errno.h>
+	# include <fcntl.h>
+}
+#endif							 // _WINDOWS
+#endif							 // MAKEDEPEND
+
+using namespace XmlRpc;
+
+SSL_CTX *XmlRpcSocket::ctx = NULL;
+std::map<int, SSL*> XmlRpcSocket::ssl_map;
+
+#if defined(_WINDOWS)
+
+static void initWinSock()
+{
+	static bool wsInit = false;
+	if (! wsInit)
+	{
+		WORD wVersionRequested = MAKEWORD( 2, 0 );
+		WSADATA wsaData;
+		WSAStartup(wVersionRequested, &wsaData);
+		wsInit = true;
+	}
+}
+
+
+#else
+
+#define initWinSock()
+#endif							 // _WINDOWS
+
+// These errors are not considered fatal for an IO operation; the operation will be re-tried.
+static inline bool
+nonFatalError()
+{
+	int err = XmlRpcSocket::getError();
+	return (err == EINPROGRESS || err == EAGAIN || err == EWOULDBLOCK || err == EINTR);
+}
+
+int
+XmlRpcSocket::initSSL(const char *certFile, const char *keyFile)
+{
+	SSL_load_error_strings();
+	OpenSSL_add_ssl_algorithms();
+
+	ctx = SSL_CTX_new(SSLv23_server_method());
+
+	// load cacert key pair
+	SSL_CTX_use_certificate_file(ctx, certFile, SSL_FILETYPE_PEM);
+	SSL_CTX_use_PrivateKey_file(ctx, keyFile, SSL_FILETYPE_PEM);
+	if (!SSL_CTX_check_private_key(ctx))
+		return -1;
+
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+	return 0;
+}
+
+int
+XmlRpcSocket::socket()
+{
+	initWinSock();
+	return (int) ::socket(AF_INET, SOCK_STREAM, 0);
+}
+
+
+void
+XmlRpcSocket::close(int fd)
+{
+	XmlRpcUtil::log(4, "XmlRpcSocket::close: fd %d.", fd);
+	#if defined(_WINDOWS)
+	closesocket(fd);
+	#else
+	::close(fd);
+	#endif						 // _WINDOWS
+}
+
+bool
+XmlRpcSocket::setNonBlocking(int fd)
+{
+	#if defined(_WINDOWS)
+	unsigned long flag = 1;
+	return (ioctlsocket((SOCKET)fd, FIONBIO, &flag) == 0);
+	#else
+	return (fcntl(fd, F_SETFL, O_NONBLOCK) == 0);
+	#endif						 // _WINDOWS
+}
+
+bool
+XmlRpcSocket::unsetNonBlocking(int fd)
+{
+	#if defined(_WINDOWS)
+	unsigned long flag = 1;
+	return (ioctlsocket((SOCKET)fd, 0, &flag) == 0);
+	#else
+	return (fcntl(fd, F_SETFL, 0) == 0);
+	#endif						 // _WINDOWS
+}
+
+bool
+XmlRpcSocket::setReuseAddr(int fd)
+{
+	// Allow this port to be re-bound immediately so server re-starts are not delayed
+	int sflag = 1;
+	return (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&sflag, sizeof(sflag)) == 0);
+}
+
+
+// Bind to a specified port
+bool
+XmlRpcSocket::bind(int fd, int port)
+{
+	struct sockaddr_in saddr;
+	memset(&saddr, 0, sizeof(saddr));
+	saddr.sin_family = AF_INET;
+	saddr.sin_addr.s_addr = htonl(INADDR_ANY);
+	saddr.sin_port = htons((u_short) port);
+	return (::bind(fd, (struct sockaddr *)&saddr, sizeof(saddr)) == 0);
+}
+
+
+// Set socket in listen mode
+bool
+XmlRpcSocket::listen(int fd, int backlog)
+{
+	return (::listen(fd, backlog) == 0);
+}
+
+
+int
+#ifdef _WINDOWS
+XmlRpcSocket::accept(int fd, struct sockaddr_in &addr, int &addrlen)
+#else
+XmlRpcSocket::accept(int fd, struct sockaddr_in &addr, socklen_t &addrlen)
+#endif
+{
+	addrlen = sizeof(addr);
+
+	int _fd = ::accept(fd, (struct sockaddr*)&addr, &addrlen);
+	SSL *ssl = SSL_new(ctx);
+
+	SSL_set_fd(ssl, _fd);
+	SSL_accept(ssl);
+	ssl_map[_fd] = ssl;
+
+	return _fd;
+}
+
+
+// Connect a socket to a server (from a client)
+bool
+XmlRpcSocket::connect(int fd, std::string& host, int port)
+{
+	struct sockaddr_in saddr;
+	memset(&saddr, 0, sizeof(saddr));
+	saddr.sin_family = AF_INET;
+
+	struct hostent *hp = gethostbyname(host.c_str());
+	if (hp == 0) return false;
+
+	saddr.sin_family = hp->h_addrtype;
+	memcpy(&saddr.sin_addr, hp->h_addr, hp->h_length);
+	saddr.sin_port = htons((u_short) port);
+
+	// For asynch operation, this will return EWOULDBLOCK (windows) or
+	// EINPROGRESS (linux) and we just need to wait for the socket to be writable...
+	int result = ::connect(fd, (struct sockaddr *)&saddr, sizeof(saddr));
+	return result == 0 || nonFatalError();
+}
+
+
+// Read available text from the specified socket. Returns false on error.
+bool
+XmlRpcSocket::nbRead(int fd, char* &s, int &l, bool *eof)
+{
+	const int READ_SIZE = 4096;	 // Number of bytes to attempt to read at a time
+	char readBuf[READ_SIZE];
+
+	bool wouldBlock = false;
+	*eof = false;
+
+	SSL *ssl = ssl_map[fd];
+
+	while ( ! wouldBlock && ! *eof)
+	{
+		int n = SSL_read(ssl, readBuf, READ_SIZE-1);
+		XmlRpcUtil::log(5, "XmlRpcSocket::nbRead: read/recv returned %d.", n);
+
+		if (n > 0)
+		{
+			readBuf[n] = 0;
+			s = (char*) realloc(s, l + n + 1);
+			memcpy(s + l, readBuf, n + 1);
+			l += n;
+		}
+		else if (n == 0)
+		{
+			*eof = true;
+		}
+		else if (nonFatalError())
+		{
+			wouldBlock = true;
+		}
+		else
+		{
+			return false;		 // Error
+		}
+	}
+	return true;
+}
+
+
+// Write text to the specified socket. Returns false on error.
+size_t
+XmlRpcSocket::nbWrite(int fd, std::string s, size_t *bytesSoFar, bool sendfull)
+{
+	int nToWrite = int(s.length()) - *bytesSoFar;
+	char *sp = const_cast<char*>(s.c_str()) + *bytesSoFar;
+
+	SSL *ssl = ssl_map[fd];
+	while ( nToWrite > 0 )
+	{
+		int n = SSL_write(ssl, sp, nToWrite);
+
+		if (n > 0)
+		{
+			sp += n;
+			*bytesSoFar += n;
+			nToWrite -= n;
+			XmlRpcUtil::log(5, "XmlRpcSocket::nbWrite: send/write returned %d.", n);
+		}
+		else if (nonFatalError())
+		{
+			if (!sendfull)
+				return n;
+		}
+		else
+		{
+			XmlRpcUtil::log(5, "XmlRpcSocket::nbWrite: send error %s (%d)", strerror(errno), errno);
+			return -1;		 // Error
+		}
+	}
+	return 0;
+}
+
+
+// Write text to the specified socket. Returns false on error.
+size_t
+XmlRpcSocket::nbWriteBuf(int fd, const char *buf, size_t buf_len, size_t *bytesSoFar, bool sendfull, bool retry)
+{
+	size_t nToWrite = buf_len - *bytesSoFar;
+
+	SSL *ssl = ssl_map[fd];
+	while ( nToWrite > 0 )
+	{
+		int n = SSL_write(ssl, buf + *bytesSoFar, nToWrite);
+		XmlRpcUtil::log(5, "XmlRpcSocket::nbWrite: send/write returned %d.", n);
+
+		if (n > 0)
+		{
+			*bytesSoFar += n;
+			nToWrite -= n;
+			if (retry == false)
+				return 0;
+		}
+		else if (nonFatalError())
+		{
+			if (retry == false)
+				return 0;
+			if (!sendfull)
+				return n;
+		}
+		else
+		{
+			return -1;		 // Error
+		}
+	}
+	return 0;
+}
+
+
+
+// Returns last errno
+int
+XmlRpcSocket::getError()
+{
+	#if defined(_WINDOWS)
+	return WSAGetLastError();
+	#else
+	return errno;
+	#endif
+}
+
+
+// Returns message corresponding to last errno
+std::string
+XmlRpcSocket::getErrorMsg()
+{
+	return getErrorMsg(getError());
+}
+
+
+// Returns message corresponding to errno... well, it should anyway
+std::string
+XmlRpcSocket::getErrorMsg(int error)
+{
+	char err[120];
+        #if defined(_WINDOWS)
+	snprintf(err,sizeof(err),"error %d", error);
+	#else
+	snprintf(err,sizeof(err),"error %d(%s)", error, strerror(error));
+	#endif
+	return std::string(err);
+}

--- a/src/httpd/httpd.cpp
+++ b/src/httpd/httpd.cpp
@@ -47,6 +47,8 @@ using namespace Magick;
 #define OPT_TESTSCRIPT          OPT_LOCAL + 78
 #define OPT_DEBUG_TESTSCRIPT    OPT_LOCAL + 79
 #define OPT_BB_QUEUE            OPT_LOCAL + 80
+#define OPT_SSL_CERT            OPT_LOCAL + 81
+#define OPT_SSL_KEY             OPT_LOCAL + 82
 
 using namespace XmlRpc;
 
@@ -486,6 +488,14 @@ int XmlRpcd::processOption (int in_opt)
 		case 'p':
 			rpcPort = atoi (optarg);
 			break;
+#ifdef RTS2_SSL
+		case OPT_SSL_CERT:
+			sslCert = optarg;
+			break;
+		case OPT_SSL_KEY:
+			sslKey = optarg;
+			break;
+#endif
 		case OPT_STATE_CHANGE:
 			stateChangeFile = optarg;
 			break;
@@ -533,6 +543,16 @@ int XmlRpcd::init ()
 
 	if (printDebug ())
 		XmlRpc::setVerbosity (5);
+
+#ifdef RTS2_SSL
+	if (sslKey == "" || sslCert == "") {
+		Configuration::instance ()->getString ("xmlrpcd", "ssl_cert", sslCert, "");
+		Configuration::instance ()->getString ("xmlrpcd", "ssl_key", sslKey, "");
+	}
+	if (sslKey == "" || sslCert == "")
+		abort();
+	initSSL(sslCert.c_str(), sslKey.c_str());
+#endif
 
 	XmlRpcServer::bindAndListen (rpcPort);
 	XmlRpcServer::enableIntrospection (true);
@@ -784,6 +804,10 @@ XmlRpcd::XmlRpcd (int argc, char **argv): rts2core::Device (argc, argv, DEVICE_T
 	addOption (OPT_DEBUG_TESTSCRIPT, "debug-test-script", 0, "print test script debugging");
 	addOption (OPT_TESTSCRIPT, "test-script", 1, "test script to run on background");
 	addOption (OPT_BB_QUEUE, "bb-queue", 1, "name of queue used for BB scheduling");
+#ifdef RTS2_SSL
+	addOption (OPT_SSL_CERT, "ssl-cert", 1, "OpenSSL ca certification file");
+	addOption (OPT_SSL_KEY, "ssl-key", 1, "OpenSSL private key file");
+#endif
 	XmlRpc::setVerbosity (0);
 }
 

--- a/src/httpd/httpd.h
+++ b/src/httpd/httpd.h
@@ -609,6 +609,11 @@ class XmlRpcd:public rts2core::Device, XmlRpc::XmlRpcServer, rts2json::HTTPServe
 
 		std::list <const char *> testScripts;
 		bool debugTestscript;
+
+#ifdef RTS2_SSL
+		std::string sslCert;
+		std::string sslKey;
+#endif
 };
 
 


### PR DESCRIPTION
Enable OpenSSL support by `./configure --enable-ssl`, default to no.
Add two options to rts2-httpd to specify certification key file, --ssl-key and --ssl-cert.
These options can also be specified in /etc/rts2/rts2.ini.

Problems:
Cannot enable both unsecure access and https access simultaneously.
CA certification key must has no password, since OpenSSL use stdin to input password, which is closed by default.