### PR TITLE
Refer to wcstools as wcstools instead of wcslib

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,6 +24,10 @@ Instalation from SVN
    you begin, important note: on Ubuntu 64bit installations, you need to
    compile wcs with -fPIC CFLAG.
 
+   Note that as of April 2016 libwcstools-dev is available in both Debian and
+   Ubuntu and should be installed via the package manager, rather than the
+   process described here.
+
 user@host:wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.8.1.tar.gz
 user@host:tar xzf wcstools-3.7.7.tar.gz
 user@host:cd wcstools-3.7.7/
@@ -48,8 +52,8 @@ make[1]: Leaving directory `/home/petr/wcstools-3.7.7/libned'
 cc -g -o bin/nedpos nedpos.c libwcs/libwcs.a -lm libned/libned.a
 cc -g -o bin/bincat bincat.c libwcs/libwcs.a -lm
 user@host:~/wcstools-3.7.7$ cd libwcs
-user@host:~/wcstools-3.7.7/libwcs$ sudo mkdir /usr/local/include/wcs
-user@host:~/wcstools-3.7.7/libwcs$ sudo cp *.h /usr/local/include/wcs/
+user@host:~/wcstools-3.7.7/libwcs$ sudo mkdir /usr/local/include/wcstools
+user@host:~/wcstools-3.7.7/libwcs$ sudo cp *.h /usr/local/include/wcstools/
 user@host:~/wcstools-3.7.7/libwcs$ sudo cp libwcs.a /usr/local/lib/libwcstools.a
 
    For inpatient (works on Debian/etch, Ubuntu, SuSe, ..)

--- a/INSTALL
+++ b/INSTALL
@@ -48,9 +48,9 @@ make[1]: Leaving directory `/home/petr/wcstools-3.7.7/libned'
 cc -g -o bin/nedpos nedpos.c libwcs/libwcs.a -lm libned/libned.a
 cc -g -o bin/bincat bincat.c libwcs/libwcs.a -lm
 user@host:~/wcstools-3.7.7$ cd libwcs
-user@host:~/wcstools-3.7.7/libwcs$ sudo mkdir /usr/local/include/libwcs
-user@host:~/wcstools-3.7.7/libwcs$ sudo cp *.h /usr/local/include/libwcs/
-user@host:~/wcstools-3.7.7/libwcs$ sudo cp libwcs.a /usr/local/lib/
+user@host:~/wcstools-3.7.7/libwcs$ sudo mkdir /usr/local/include/wcs
+user@host:~/wcstools-3.7.7/libwcs$ sudo cp *.h /usr/local/include/wcs/
+user@host:~/wcstools-3.7.7/libwcs$ sudo cp libwcs.a /usr/local/lib/libwcstools.a
 
    For inpatient (works on Debian/etch, Ubuntu, SuSe, ..)
 

--- a/configure.ac
+++ b/configure.ac
@@ -211,13 +211,13 @@ AC_ARG_WITH(pgsql,
 	*) AC_MSG_ERROR(bad value ${withval} for --without-pgsql) ;;
 esac],[psql=yes])
 
-AC_ARG_WITH(wcs,
-[  --with-wcs           path to WCS programs],
+AC_ARG_WITH(wcstools,
+[  --with-wcstools           path to WCS programs],
 [case "${withval}" in
-	yes) libwcs=yes ;;
-	no)  libwcs=no ;;
-	*) libwcs=${withval} ;;
-esac],[libwcs=yes])
+	yes) libwcstools=yes ;;
+	no)  libwcstools=no ;;
+	*) libwcstools=${withval} ;;
+esac],[libwcstools=yes])
 
 
 # check for EPICS
@@ -602,13 +602,13 @@ exit 1])
   AC_SUBST(LIB_CFITSIO)
 ])
 
-AS_IF([test "x${libwcs}" != "xno"], [
-  AS_IF([test "x${libwcs}" != "xyes"], [
-    LDFLAGS="${LDFLAGS} -L${libwcs}/libwcs"
+AS_IF([test "x${libwcstools}" != "xno"], [
+  AS_IF([test "x${libwcstools}" != "xyes"], [
+    LDFLAGS="${LDFLAGS} -L${libwcstools}/libwcstools"
   ])
-  AC_CHECK_LIB([wcs], [wcs2pix], LIBWCS_LDFLAGS="-lwcs", 
+  AC_CHECK_LIB([wcstools], [wcs2pix], LIBWCS_LDFLAGS="-lwcstools", 
   [cat <<EOF
-**** You don't have libwcs installed.
+**** You don't have wcstools installed.
 **** You can download one from
 **** http://tdc-www.harvard.edu/software/wcstools/.
 **** Please note that there is no standart procedure to install
@@ -616,15 +616,15 @@ AS_IF([test "x${libwcs}" != "xno"], [
 **** WCS library.
 EOF
   exit 1])
-  AS_IF([test "x${libwcs}" != "xyes"], [
-    LIBWCS_LDFLAGS="-L${libwcs}/libwcs -lwcs"
-    LIBWCS_CFLAGS="-I${libwcs}"
+  AS_IF([test "x${libwcstools}" != "xyes"], [
+    LIBWCS_LDFLAGS="-L${libwcstools}/libwcstools -lwcstools"
+    LIBWCS_CFLAGS="-I${libwcstools}"
   ], [
-    LIBWCS_LDFLAGS="-lwcs"
+    LIBWCS_LDFLAGS="-lwcstools"
   ])
 ])
 
-AM_CONDITIONAL(LIBWCS, test x$libwcs != xno)
+AM_CONDITIONAL(LIBWCS, test x$libwcstools != xno)
 AC_SUBST(LIBWCS_CFLAGS)
 AC_SUBST(LIBWCS_LDFLAGS)
 
@@ -998,7 +998,7 @@ echo "
   libusb1	${libusb1}
   libusb	${libusb}
   cfitsio       ${cfitsio}
-  libwcs        ${libwcs}
+  libwcstools        ${libwcstools}
   pgsql		${psql}
   gpib          ${GPIBLIB}
   comedilib     ${COMEDI}

--- a/src/db/tpm.cpp
+++ b/src/db/tpm.cpp
@@ -23,8 +23,8 @@
 #include <math.h>
 #include <time.h>
 #include <libnova/libnova.h>
-#include <libwcs/wcs.h>
-#include <libwcs/fitsfile.h>
+#include <wcstools/wcs.h>
+#include <wcstools/fitsfile.h>
 
 #include <ostream>
 #include <iostream>

--- a/src/pgsql/pg_wcs.c
+++ b/src/pgsql/pg_wcs.c
@@ -25,7 +25,7 @@
 PG_MODULE_MAGIC;
 #endif
 
-#include <libwcs/wcs.h>
+#include <wcstools/wcs.h>
 
 #include <ctype.h>
 #include <string.h>


### PR DESCRIPTION
Wondering why the configure script couldn't find wcslib (which I have installed), I discovered that what it really wanted was wcstools (which I did not have installed).  This pull request fixes that, and also updates the instructions to note that wcstools is now available in both Debian and Ubuntu.