### PR TITLE
Added Gentoo to init script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,6 +556,7 @@ LOCK_PREFIX="/var/run/rts2_")
 AH_TEMPLATE([LOCK_PREFIX],[Lock file prefix path])
 
 AC_DEFINE_UNQUOTED(LOCK_PREFIX, "$LOCK_PREFIX", [Lock file prefix path])
+AC_SUBST(LOCK_PREFIX)
 
 # Default centrald port
 AC_ARG_WITH(port,

--- a/rts2.initd.in
+++ b/rts2.initd.in
@@ -229,8 +229,12 @@ rts2_start()
 			centrald_options="--local-port $centrald_port $centrald_options"
 		fi
 		case $system in
-			gentoo|debian)
+			debian)
 				start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}centrald_${centrald_port} --exec $RTS2_BIN_PREFIX/rts2-centrald -- $centrald_options >>$RTS2_LOG 2>&1
+				rts2_start_log_end_msg $? "rts2-centrald $centrald_options" "centrald daemon on port $centrald_port"
+				;;
+			gentoo)
+				busybox start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}centrald_${centrald_port} --exec $RTS2_BIN_PREFIX/rts2-centrald -- $centrald_options >>$RTS2_LOG 2>&1
 				rts2_start_log_end_msg $? "rts2-centrald $centrald_options" "centrald daemon on port $centrald_port"
 				;;
 			redhat|suse|slackware|cygwin)
@@ -242,12 +246,21 @@ rts2_start()
 	CENTRALD_OPTIONS=`grep '^-' $CENTRALD_FILE 2>/dev/null`
 	while read device type device_name options; do
 		case $system in
-			gentoo|debian)
+			debian)
 				# some devices do not like to have device name on command line
 				if [ "x$device_name" == "x-" ]; then
 					start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${device_name} --exec $RTS2_BIN_PREFIX/rts2-$device-$type -- $options $CENTRALD_OPTIONS >>$RTS2_LOG 2>&1 
 				else
 					start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${device_name} --exec $RTS2_BIN_PREFIX/rts2-$device-$type -- $options $CENTRALD_OPTIONS -d $device_name >>$RTS2_LOG 2>&1
+				fi 
+				rts2_start_log_end_msg $? $device_name "$device_name"
+				;;
+			gentoo)
+				# some devices do not like to have device name on command line
+				if [ "x$device_name" == "x-" ]; then
+					busybox start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${device_name} --exec $RTS2_BIN_PREFIX/rts2-$device-$type -- $options $CENTRALD_OPTIONS >>$RTS2_LOG 2>&1 
+				else
+					busybox start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${device_name} --exec $RTS2_BIN_PREFIX/rts2-$device-$type -- $options $CENTRALD_OPTIONS -d $device_name >>$RTS2_LOG 2>&1
 				fi 
 				rts2_start_log_end_msg $? $device_name "$device_name"
 				;;
@@ -264,8 +277,12 @@ rts2_start()
 	done < <(cat $DEVICE_CONFIG | sed -e 's/#.*$//' | egrep -v '^\s*$')
 	while read service service_name options; do
 		case $system in
-			gentoo|debian)
+			debian)
 				start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${service_name} --exec $RTS2_BIN_PREFIX/rts2-$service -- $options $CENTRALD_OPTIONS -d $service_name >>$RTS2_LOG 2>&1
+				rts2_start_log_end_msg $? $service_name "$service_name"
+				;;
+			gentoo)
+				busybox start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${service_name} --exec $RTS2_BIN_PREFIX/rts2-$service -- $options $CENTRALD_OPTIONS -d $service_name >>$RTS2_LOG 2>&1
 				rts2_start_log_end_msg $? $service_name "$service_name"
 				;;
 			redhat|suse|slackware|cygwin)
@@ -289,9 +306,15 @@ rts2_stop_devices()
 {
 	while read device type device_name options; do
 		case $system in
-			gentoo|debian)
+			debian)
 				if [ -e ${RTS2_PID_PREFIX}${device_name} ]; then
 					start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${device_name} >>$RTS2_LOG 2>&1
+					rts2_stop_log_end_msg $? $device_name
+				fi
+				;;
+			gentoo)
+				if [ -e ${RTS2_PID_PREFIX}${device_name} ]; then
+					busybox start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${device_name} >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? $device_name
 				fi
 				;;
@@ -310,9 +333,15 @@ rts2_stop_services()
 {
 	while read service service_name options; do
 		case $system in
-			gentoo|debian)
+			debian)
 				if [ -e ${RTS2_PID_PREFIX}$service_name ]; then
 					start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${service_name} >>$RTS2_LOG 2>&1
+					rts2_stop_log_end_msg $? $service_name
+				fi
+				;;
+			gentoo)
+				if [ -e ${RTS2_PID_PREFIX}$service_name ]; then
+					busybox start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${service_name} >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? $service_name
 				fi
 				;;
@@ -335,8 +364,12 @@ rts2_stop()
 	if grep '^centrald' $CENTRALD_FILE 2>&1 > /dev/null; then
 		for cf in ${RTS2_PID_PREFIX}centrald_*; do
 		  	case $system in
-				gentoo|debian)
+				debian)
 					start-stop-daemon --stop --pidfile $cf >>$RTS2_LOG 2>&1
+					rts2_stop_log_end_msg $? rts2-centrald
+					;;
+				gentoo)
+					busybox start-stop-daemon --stop --pidfile $cf >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? rts2-centrald
 					;;
 				redhat|suse|slackware|cygwin)

--- a/rts2.initd.in
+++ b/rts2.initd.in
@@ -45,6 +45,8 @@ elif [ -f /etc/SuSE-release ]; then
 	system=suse
 elif [ -f /etc/slackware-version ]; then
 	system=slackware
+elif [ -f /etc/gentoo-release ]; then
+	system=gentoo
 elif [ `uname -o` == 'Cygwin' ]; then
 	system=cygwin
 else
@@ -56,6 +58,54 @@ fi
 case $system in
 	debian)
 		. /lib/lsb/init-functions
+		;;
+	gentoo)
+		. /etc/init.d/functions.sh
+		function log_daemon_msg
+		{
+			einfo $*
+		}
+
+		function log_progress_msg
+		{
+			einfo $*
+		}
+
+		function log_warning_msg
+		{
+			ewarn $*
+		}
+
+		function log_failure_msg
+		{
+			eerror $*
+		}
+
+		function log_success_msg
+		{
+			einfo $*
+		}
+
+		function log_end_msg
+		{
+			if [ $1 == 0 ]; then
+				einfo "ok"
+			else
+				eend $1 "failed"
+				failedc=`expr $failedc + 1`
+			fi
+		}
+
+		function wait_pid
+		{
+			if [ $2 == 0 ]; then
+				until [ -s $1 ]; do
+					echo -n "."
+					sleep 1
+				done
+			fi
+			rts2_start_log_end_msg $2 $3
+		}
 		;;
 	slackware|redhat|suse|cygwin)
 		# Source function library.
@@ -130,7 +180,7 @@ CENTRALD_FILE=@PREFIX@/etc/rts2/centrald
 DEVICE_CONFIG=@PREFIX@/etc/rts2/devices
 SERVICE_CONFIG=@PREFIX@/etc/rts2/services
 RTS2_BIN_PREFIX=@prefix@/bin
-RTS2_PID_PREFIX=@PREFIX@/var/run/rts2_
+RTS2_PID_PREFIX=@LOCK_PREFIX@
 RTS2_LOG=@PREFIX@/var/log/rts2-debug
 
 rts2_log_daemon_msg()
@@ -157,7 +207,7 @@ rts2_start_log_end_msg()
 rts2_stop_log_end_msg()
 {
 	if [ $1 == 0 ]; then
-		log_success_msg "Stoping RTS2 $2"
+		log_success_msg "Stopping RTS2 $2"
 		echo `date +'%Y-%m-%dT%H:%M:%S %Z'` '===>>> ok' $2 >>$RTS2_LOG
 	elif [ $1 == 1 ]; then
 		log_warning_msg "RTS2 $2 already stopped"
@@ -179,7 +229,7 @@ rts2_start()
 			centrald_options="--local-port $centrald_port $centrald_options"
 		fi
 		case $system in
-			debian)
+			gentoo|debian)
 				start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}centrald_${centrald_port} --exec $RTS2_BIN_PREFIX/rts2-centrald -- $centrald_options >>$RTS2_LOG 2>&1
 				rts2_start_log_end_msg $? "rts2-centrald $centrald_options" "centrald daemon on port $centrald_port"
 				;;
@@ -192,7 +242,7 @@ rts2_start()
 	CENTRALD_OPTIONS=`grep '^-' $CENTRALD_FILE 2>/dev/null`
 	while read device type device_name options; do
 		case $system in
-			debian)
+			gentoo|debian)
 				# some devices do not like to have device name on command line
 				if [ "x$device_name" == "x-" ]; then
 					start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${device_name} --exec $RTS2_BIN_PREFIX/rts2-$device-$type -- $options $CENTRALD_OPTIONS >>$RTS2_LOG 2>&1 
@@ -214,7 +264,7 @@ rts2_start()
 	done < <(cat $DEVICE_CONFIG | sed -e 's/#.*$//' | egrep -v '^\s*$')
 	while read service service_name options; do
 		case $system in
-			debian)
+			gentoo|debian)
 				start-stop-daemon --start --pidfile ${RTS2_PID_PREFIX}${service_name} --exec $RTS2_BIN_PREFIX/rts2-$service -- $options $CENTRALD_OPTIONS -d $service_name >>$RTS2_LOG 2>&1
 				rts2_start_log_end_msg $? $service_name "$service_name"
 				;;
@@ -237,9 +287,9 @@ rts2_start()
 
 rts2_stop_devices()
 {
-	cat $DEVICE_CONFIG | sed -e 's/#.*$//' | egrep -v '^\s*$' | while read device type device_name options; do
+	while read device type device_name options; do
 		case $system in
-			debian)
+			gentoo|debian)
 				if [ -e ${RTS2_PID_PREFIX}${device_name} ]; then
 					start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${device_name} >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? $device_name
@@ -253,14 +303,14 @@ rts2_stop_devices()
 				fi
 				;;
 		esac
-	done
+	done < <(cat $DEVICE_CONFIG | sed -e 's/#.*$//' | egrep -v '^\s*$')
 }
 
 rts2_stop_services()
 {
 	while read service service_name options; do
 		case $system in
-			debian)
+			gentoo|debian)
 				if [ -e ${RTS2_PID_PREFIX}$service_name ]; then
 					start-stop-daemon --stop --pidfile ${RTS2_PID_PREFIX}${service_name} >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? $service_name
@@ -285,7 +335,7 @@ rts2_stop()
 	if grep '^centrald' $CENTRALD_FILE 2>&1 > /dev/null; then
 		for cf in ${RTS2_PID_PREFIX}centrald_*; do
 		  	case $system in
-				debian)
+				gentoo|debian)
 					start-stop-daemon --stop --pidfile $cf >>$RTS2_LOG 2>&1
 					rts2_stop_log_end_msg $? rts2-centrald
 					;;
@@ -315,7 +365,7 @@ rts2_reload()
 		for cf in ${RTS2_PID_PREFIX}centrald_*; do
 			pid=`cat $cf`
 			case $system in
-				debian|redhat|suse|slackware|cygwin)
+				gentoo|debian|redhat|suse|slackware|cygwin)
 					rts2_log_daemon_msg "Reloading centrald daemon (PID $cf)" "rts2-centrald"
 				  	kill -1 `cat $cf` >>$RTS2_LOG 2>&1
 					rts2_start_log_end_msg $? rts2-centrald
@@ -326,7 +376,7 @@ rts2_reload()
 	while read device type device_name options; do
 		if [ -f ${RTS2_PID_PREFIX}${device_name} ]; then
 		  	case $system in
-				debian|redhat|suse|slackware|cygwin)
+				gentoo|debian|redhat|suse|slackware|cygwin)
 					rts2_log_daemon_msg "Reloading $device_name" "rts2-$device-$type"
 					kill -1 `cat ${RTS2_PID_PREFIX}${device_name}` >>$RTS2_LOG 2>&1
 					rts2_start_log_end_msg $? $device_name
@@ -337,7 +387,7 @@ rts2_reload()
 	while read service service_name options; do
 		if [ -f ${RTS2_PID_PREFIX}${service_name} ]; then
 		  	case $system in
-				debian|redhat|suse|slackware|cygwin)
+				gentoo|debian|redhat|suse|slackware|cygwin)
 					rts2_log_daemon_msg "Reloading $service_name" "rts2-$service"
 					kill -1 `cat ${RTS2_PID_PREFIX}${service_name}` >>$RTS2_LOG 2>&1
 					rts2_start_log_end_msg $? $service_name
@@ -377,7 +427,7 @@ case $system in
 	debian)
 		exit 0
 		;;
-	redhat|suse|slackware|cygwin)
+	gentoo|redhat|suse|slackware|cygwin)
 		exit $failedc 
 		;;
 esac


### PR DESCRIPTION
Add Gentoo to the init script.  Also fix a bug with lockfiles not being found when --with-lock is used.