### PR TITLE
add library dependencies to their LIBADD variables

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = xmlrpc++ pluto sgp4 rts2 rts2db rts2fits rts2lx200 rts2script rts2scheduler rts2json libindi rts2tel
+SUBDIRS = rts2 xmlrpc++ pluto sgp4 rts2db rts2fits rts2script rts2scheduler rts2json libindi rts2tel rts2lx200

--- a/lib/rts2/Makefile.am
+++ b/lib/rts2/Makefile.am
@@ -1,6 +1,6 @@
 # Process this file with automake to produce Makefile.in
 
-SUBDIRS = vermes  
+SUBDIRS = vermes
 
 AM_CXXFLAGS=@NOVA_CFLAGS@ -I../../include
 AM_CFLAGS=@NOVA_CFLAGS@ -I../../include
@@ -23,16 +23,18 @@ librts2_la_SOURCES = hoststring.cpp app.cpp block.cpp daemon.cpp device.cpp mult
 	tgdrive.cpp clicupola.cpp cliwheel.cpp clifocuser.cpp clirotator.cpp slitazimuth.c connthorlabs.cpp \
 	dirsupport.cpp userpermissions.cpp conntcsng.cpp connethernet.cpp connremotes.cpp connsitech.cpp \
 	catd.cpp
+librts2_la_LIBADD = @LIB_NOVA@
 
 librts2gpib_la_SOURCES = sensorgpib.cpp conngpib.cpp conngpibenet.cpp conngpibprologix.cpp conngpibserial.cpp connscpi.cpp
+librts2gpib_la_LIBADD = librts2.la
 
 if GPIBLIB
 librts2gpib_la_SOURCES += conngpiblinux.cpp
-librts2gpib_la_LIBADD = @LIB_GPIB@
+librts2gpib_la_LIBADD += @LIB_GPIB@
 else
 EXTRA_DIST += conngpiblinux.cpp
 endif
-	
+
 if SUNCYGMAC
 EXTRA_DIST += OakFeatureReports.c OakHidBase.c
 else
@@ -40,6 +42,7 @@ librts2_la_SOURCES += OakFeatureReports.c OakHidBase.c
 endif
 
 librts2users_la_SOURCES = userlogins.cpp
+librts2users_la_LIBADD = librts2.la @LIB_CRYPT@
 
 # CYGWIN workaround
 if NOT_GETADDRINFO

--- a/lib/rts2/vermes/Makefile.am
+++ b/lib/rts2/vermes/Makefile.am
@@ -5,3 +5,4 @@ AM_CFLAGS=@NOVA_CFLAGS@  -I../../../include
 librts2vermes_la_SOURCES= move_door.c \
 	move_to_target_az.c barcodereader.c ssd650v_comm.c \
 	bisync.c util.c serial.c oak_comm.c
+librts2vermes_la_LIBADD = ../librts2.la @LIB_NOVA@ @LIB_PTHREAD@

--- a/lib/rts2db/Makefile.am
+++ b/lib/rts2db/Makefile.am
@@ -27,6 +27,8 @@ nodist_librts2db_la_SOURCES = sqlerror.cpp devicedb.cpp target.cpp sub_targets.c
 	augerset.cpp labels.cpp labellist.cpp queues.cpp
 
 librts2db_la_SOURCES = simbadtarget.cpp mpectarget.cpp imagesetstat.cpp constraints.cpp
+librts2db_la_LIBADD = ../rts2/librts2.la ../pluto/libpluto.la ../xmlrpc++/librts2xmlrpc.la \
+	@LIBPG_LIBS@ @LIBXML_LIBS@ @CFITSIO_LIBS@ @MAGIC_LIBS@ @LIB_ECPG@ @LIB_CRYPT@
 
 .ec.cpp:
 	@ECPG@ -o $@ $^

--- a/lib/rts2fits/Makefile.am
+++ b/lib/rts2fits/Makefile.am
@@ -8,6 +8,7 @@ CLEANFILES = imagedb.cpp dbfilters.cpp
 
 librts2image_la_SOURCES = fitsfile.cpp channel.cpp image.cpp imageastrometry.cpp devcliimg.cpp cameraimage.cpp devclifoc.cpp imageprocess.cpp
 librts2image_la_CXXFLAGS = @NOVA_CFLAGS@ @CFITSIO_CFLAGS@ @MAGIC_CFLAGS@ -I../../include
+librts2image_la_LIBADD = ../rts2/librts2.la @CFITSIO_LIBS@ @MAGIC_LIBS@
 
 if PGSQL
 
@@ -16,6 +17,7 @@ lib_LTLIBRARIES += librts2imagedb.la
 nodist_librts2imagedb_la_SOURCES = imagedb.cpp
 librts2imagedb_la_CXXFLAGS = @LIBPG_CFLAGS@ @NOVA_CFLAGS@ @CFITSIO_CFLAGS@ @MAGIC_CFLAGS@ -I../../include
 librts2imagedb_la_SOURCES = fitsfile.cpp channel.cpp image.cpp imageastrometry.cpp devcliimg.cpp cameraimage.cpp devclifoc.cpp dbfilters.cpp
+librts2imagedb_la_LIBADD = ../rts2db/librts2db.la
 
 .ec.cpp:
 	@ECPG@ -o $@ $^

--- a/lib/rts2json/Makefile.am
+++ b/lib/rts2json/Makefile.am
@@ -4,6 +4,7 @@ librts2json_la_SOURCES = httpreq.cpp jsonvalue.cpp directory.cpp expandstrings.c
 	images.cpp targetreq.cpp altaz.cpp plot.cpp imgpreview.cpp nightdur.cpp asyncapi.cpp httpserver.cpp \
 	libcss.cpp
 librts2json_la_CXXFLAGS = -I../../include @LIBXML_CFLAGS@ -I../ @MAGIC_CFLAGS@ @CFITSIO_CFLAGS@ @NOVA_CFLAGS@
+librts2json_la_LIBADD = ../rts2/librts2.la @LIBARCHIVE_LIBS@
 
 noinst_SCRIPTS = images_convert
 
@@ -12,6 +13,7 @@ EXTRA_DIST = images_convert
 if PGSQL
 
 librts2json_la_SOURCES += jsondb.cpp altplot.cpp nightreq.cpp obsreq.cpp addtargetreq.cpp
+librts2json_la_LIBADD += ../rts2db/librts2db.la
 
 else
 

--- a/lib/rts2lx200/Makefile.am
+++ b/lib/rts2lx200/Makefile.am
@@ -3,6 +3,8 @@ lib_LTLIBRARIES = librts2pier-collision.la librts2tellx200.la
 librts2tellx200_la_SOURCES = tellx200.cpp tellx200gps.cpp hms.c
 librts2tellx200_la_CXXFLAGS = @NOVA_CFLAGS@ -I../../include
 librts2tellx200_la_CFLAGS = @NOVA_CFLAGS@ -I../../include
+librts2tellx200_la_LIBADD = ../rts2tel/librts2tel.la
 
 librts2pier_collision_la_SOURCES = pier-collision.cpp
 librts2pier_collision_la_CXXFLAGS = @NOVA_CFLAGS@ -I../../include
+librts2pier_collision_la_LIBADD = @LIB_NOVA@

--- a/lib/rts2scheduler/Makefile.am
+++ b/lib/rts2scheduler/Makefile.am
@@ -4,6 +4,7 @@ lib_LTLIBRARIES = librts2scheduler.la
 
 librts2scheduler_la_SOURCES = schedbag.cpp schedule.cpp schedobs.cpp ticket.cpp ticketset.cpp utils.cpp
 librts2scheduler_la_CXXFLAGS = @LIBPG_CFLAGS@ @CFITSIO_CFLAGS@ @MAGIC_CFLAGS@ -I../../include
+librts2scheduler_la_LIBADD = ../rts2db/librts2db.la ../rts2fits/librts2imagedb.la
 
 .ec.cpp:
 	@ECPG@ -o $@ $^

--- a/lib/rts2script/Makefile.am
+++ b/lib/rts2script/Makefile.am
@@ -10,8 +10,11 @@ librts2script_la_CXXFLAGS = @NOVA_CFLAGS@ @CFITSIO_CFLAGS@ @MAGIC_CFLAGS@ @LIBXM
 if PGSQL
 
 librts2script_la_SOURCES += printtarget.cpp execclidb.cpp elementacquire.cpp executorque.cpp simulque.cpp
+librts2script_la_LIBADD = ../rts2db/librts2db.la ../rts2fits/librts2imagedb.la
 
 else
+
+librts2script_la_LIBADD = ../rts2/librts2.la ../rts2fits/librts2image.la
 
 EXTRA_DIST = printtarget.cpp execclidb.cpp elementacquire.cpp executorque.cpp simulque.cpp
 

--- a/lib/rts2tel/Makefile.am
+++ b/lib/rts2tel/Makefile.am
@@ -3,3 +3,4 @@ lib_LTLIBRARIES = librts2tel.la
 AM_CXXFLAGS=@NOVA_CFLAGS@ -I../../include
 
 librts2tel_la_SOURCES = teld.cpp rts2model.cpp tpointmodel.cpp tpointmodelterm.cpp fork.cpp gem.cpp altaz.cpp
+librts2tel_la_LIBADD = ../rts2/librts2.la ../pluto/libpluto.la

--- a/lib/sgp4/Makefile.am
+++ b/lib/sgp4/Makefile.am
@@ -5,3 +5,4 @@ noinst_HEADERS = sgp4unit.h
 AM_CXXFLAGS = -I../../include
 
 libsgp4_la_SOURCES = sgp4unit.cpp sgp4.cpp
+libsgp4_la_LIBADD = @LIB_NOVA@

--- a/lib/xmlrpc++/Makefile.am
+++ b/lib/xmlrpc++/Makefile.am
@@ -14,11 +14,12 @@ librts2xmlrpc_la_SOURCES = \
 	XmlRpcSocket.cpp
 
 librts2xmlrpc_la_CXXFLAGS = @NOVA_CFLAGS@ -I../../include -I../../include/xmlrpc++
+librts2xmlrpc_la_LIBADD = ../rts2/librts2.la
 
 if SSL
 
 librts2xmlrpc_la_SOURCES += XmlRpcSocketSSL.cpp
-librts2xmlrpc_la_LIBADD = @SSL_LIBS@
+librts2xmlrpc_la_LIBADD += @SSL_LIBS@
 
 else
 


### PR DESCRIPTION
All libraries except librts2db now can be linked directly without other dependencies. librts2db needs to be linked with librts2imagedb.