### PR TITLE
Updated readme for Ubuntu 16.04

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,9 +28,9 @@ Instalation from Git
    Ubuntu and should be installed via the package manager, rather than the
    process described here.
 
-user@host:wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.8.1.tar.gz
-user@host:tar xzf wcstools-3.7.7.tar.gz
-user@host:cd wcstools-3.7.7/
+user@host:wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.4.tar.gz
+user@host:tar xzf wcstools-3.9.4.tar.gz
+user@host:cd wcstools-3.9.4/
 
 If you are running 64bit Linux, or encountered problems compiling RTS2,
 suggesting that compiling WCS with -fPIC will fix them:

--- a/INSTALL
+++ b/INSTALL
@@ -17,7 +17,8 @@ Instalation from Git
    libjson-glib-dev libsoup2.4-dev pkg-config
 
    Please note that postgresql-server-dev is actually postgresql-server-dev-8.3
-   on Ubuntu 9.04 and postgresql-server-dev-8.4 on 9.10.
+   on Ubuntu 9.04, postgresql-server-dev-8.4 on 9.10 and postgresql-server-dev-9.5
+   on 16.04.
 
    WCS libraries are needed for database and for rts2-f2j binary. If you wish
    to use them, you must manually install WCS using folowing steps. Just before


### PR DESCRIPTION
I have updated the INSTALL file with the new postgresql package available at with apt-get. On the other hand, I have updated "wcstools" to the last version available for download (the previous link doesn't works). 

**WARNING:** Please be sure that the newer versions of this two packages are compatible with RTS2. I haven't found errors during compillation proces. 