### PR TITLE
Prevent broken (header-only) files from polluting the queue

### DIFF
--- a/include/rts2fits/imagedb.h
+++ b/include/rts2fits/imagedb.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Database image access classes.
  * Copyright (C) 2003-2008 Petr Kubanek <petr@kubanek.net>
  *
@@ -107,7 +107,7 @@ class ImageSkyDb:public ImageDb
 		virtual int toTrash ();
 
 		virtual int saveImage ();
-		virtual int deleteFormDB ();
+		virtual int deleteFromDB ();
 		virtual int deleteImage ();
 
 		virtual bool haveOKAstrometry () { return (processBitfiedl & ASTROMETRY_OK); }

--- a/lib/rts2fits/cameraimage.cpp
+++ b/lib/rts2fits/cameraimage.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Classes for camera image.
  * Copyright (C) 2007 Petr Kubanek <petr@kubanek.net>
  *
@@ -31,6 +31,13 @@ CameraImage::~CameraImage (void)
 		delete *iter;
 	}
 	deviceWaits.clear ();
+
+	if (image && !dataWriten)
+	{
+		// Delete the image that did not receive any data - it is just a header
+		image->deleteImage();
+	}
+
 	delete image;
 	image = NULL;
 }

--- a/lib/rts2fits/imagedb.ec
+++ b/lib/rts2fits/imagedb.ec
@@ -1,4 +1,4 @@
-/* 
+/*
  * Database image access classes.
  * Copyright (C) 2003-2007 Petr Kubanek <petr@kubanek.net>
  *
@@ -363,7 +363,7 @@ int ImageSkyDb::updateAstrometry ()
 	d_img_err_dec = dec_err;
 	if (std::isnan (img_err))
 		d_img_err = getAstrometryErr ();
-	else	
+	else
 		d_img_err = img_err;
 
 	snprintf (s_astrometry.arr, 2000,
@@ -563,7 +563,7 @@ int ImageSkyDb::saveImage ()
 	return ImageDb::saveImage ();
 }
 
-int ImageSkyDb::deleteFormDB ()
+int ImageSkyDb::deleteFromDB ()
 {
 	EXEC SQL BEGIN DECLARE SECTION;
 	int d_img_id = getImgId ();


### PR DESCRIPTION
Petr, is it the right way to get rid of broken images (i.e. the ones left behind without the data after the observation is cancelled)? Will it cause some other problems somewhere?