### PR TITLE
Stop the daemon on receiving 'exit' command 

### DIFF
--- a/lib/rts2/device.cpp
+++ b/lib/rts2/device.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Device basic class.
  * Copyright (C) 2003-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -544,6 +544,7 @@ int Device::commandAuthorized (Connection * conn)
 	{
 		conn->setConnState (CONN_DELETE);
 		deleteConnection (conn);
+		endRunLoop();
 		return -1;
 	}
 	else if (conn->isCommand ("script_ends"))
@@ -755,7 +756,7 @@ void Device::setMulti ()
 	multidevPart = true;
 	setNotDaemonize ();
 	setNoLock ();
-} 
+}
 
 void Device::initAutoSave ()
 {

--- a/lib/rts2/device.cpp
+++ b/lib/rts2/device.cpp
@@ -544,7 +544,7 @@ int Device::commandAuthorized (Connection * conn)
 	{
 		conn->setConnState (CONN_DELETE);
 		deleteConnection (conn);
-		endRunLoop();
+		endRunLoop ();
 		return -1;
 	}
 	else if (conn->isCommand ("script_ends"))

--- a/src/monitor/nmonitor.cpp
+++ b/src/monitor/nmonitor.cpp
@@ -51,6 +51,8 @@ void NMonitor::sendCommand ()
 	char command[curX + 1];
 	char *cmd_top = command;
 	rts2core::Connection *conn = NULL;
+	bool sendAll = false;
+
 	comWindow->getWinString (command, curX);
 	command[curX] = '\0';
 
@@ -62,14 +64,26 @@ void NMonitor::sendCommand ()
 		if (*cmd_top == '.')
 		{
 			*cmd_top = '\0';
-			conn = getConnection (command);
+			if (!strcmp (command, "*") || !strcmp (command, "all"))
+				sendAll = true;
+			else
+				conn = getConnection (command);
+
 			*cmd_top = '.';
 			cmd_top++;
+
+			if (!conn && !sendAll)
+			{
+				// Wrong device name? Do not send it anywhere, just echo
+				comWindow->winclear ();
+				comWindow->printCommand (command);
+				return;
+			}
 			break;
 		}
 		cmd_top++;
 	}
-	if (conn == NULL)
+	if (conn == NULL && !sendAll)
 	{
 		conn = connectionAt (deviceList->getSelRow ());
 		cmd_top = command;
@@ -79,6 +93,8 @@ void NMonitor::sendCommand ()
 		oldCommand = new rts2core::Command (this, cmd_top);
 		if (conn)
 			conn->queCommand (oldCommand);
+		else if (sendAll)
+			queAll (oldCommand);
 		comWindow->winclear ();
 		comWindow->printCommand (command);
 		wmove (comWindow->getWriteWindow (), 0, 0);

--- a/src/monitor/nmonitor.cpp
+++ b/src/monitor/nmonitor.cpp
@@ -782,7 +782,15 @@ void NMonitor::processKey (int key)
 				if (key == KEY_F (7) ||
 					key == KEY_CTRL ('F') ||
 					key == KEY_CTRL ('G'))
+				{
+					if (daemonWindow) {
+						changeActive (daemonWindow);
+						activeWindow = daemonWindow;
+
+						ret = daemonWindow->injectKey (key);
+					}
 					break;
+				}
 
 				ret = comWindow->injectKey (key);
 				if (key == KEY_ENTER || key == K_ENTER)


### PR DESCRIPTION
Currently, 'exit' command does nothing very useful (just drops the connection, I suppose), and seems to be unused (could not find anything that sends it, at least). I propose to change its action into stopping the receiver' daemon, to be a faster way of "sudo rts2-stop DAEMON" without leaving rts2-mon. 