### PR TITLE
Set of fixes for function signatures in derived classes that may (potentially) lead to logic bugs

### DIFF
--- a/include/camd.h
+++ b/include/camd.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Basic camera daemon.
  * Copyright (C) 2001-2012 Petr Kubanek <petr@kubanek.net>
  *
@@ -142,7 +142,7 @@ class FilterVal
  *
  * @subsection stopexpo
  *
- * Stop current exposure. If camera hardware allows it, the image is preserved on 
+ * Stop current exposure. If camera hardware allows it, the image is preserved on
  * the chip, so it can be readout later.
  *
  * @subsection box
@@ -256,7 +256,7 @@ class Camera:public rts2core::ScriptDevice
 				setCoolTemp (nightCoolTemp->getValueFloat ());
 			}
 		}
-		
+
 		/**
 		 * Called when night ends. Can be used to switch off cooling. etc..
 		 */
@@ -331,14 +331,14 @@ class Camera:public rts2core::ScriptDevice
 		 * Camera::switchCooling to make sure that the value is
 		 * updated.
 		 */
-		virtual int switchCooling (bool newval) 
-		{ 
+		virtual int switchCooling (bool newval)
+		{
 			if (coolingOnOff)
 			{
 				coolingOnOff->setValueBool (newval);
 				sendValueAll (coolingOnOff);
 			}
-			return 0; 
+			return 0;
 		}
 
 		rts2core::ValueSelection * camFilterVal;
@@ -421,7 +421,7 @@ class Camera:public rts2core::ScriptDevice
 		}
 
 		/**
-		 * Set data type to given value. Value is index to dataType selection, created in 
+		 * Set data type to given value. Value is index to dataType selection, created in
 		 * initDataTypes method.
 		 *
 		 * @param ntype new data type index
@@ -458,7 +458,7 @@ class Camera:public rts2core::ScriptDevice
 			logStream (MESSAGE_WARNING) << "fits data without exposure connection, no data will be received" << sendLog;
 			return 0;
 		}
-		
+
 		/**
 		 * Return number of bytes which are left from the image.
 		 *
@@ -617,7 +617,7 @@ class Camera:public rts2core::ScriptDevice
 		rts2core::ValueString *serialNumber;
 		rts2core::ValueString *ccdChipType;
 
-		virtual void checkQueChanges (int fakeState);
+		virtual void checkQueChanges (rts2_status_t fakeState);
 
 		void checkQueuedExposures ();
 
@@ -768,7 +768,7 @@ class Camera:public rts2core::ScriptDevice
 		 * Called after isExposing returned 0.
 		 *
 		 * @param ret  return value of last isExposure call
-		 * 
+		 *
 		 * @return -1 on error, 0 on success.
 		 */
 		virtual int endExposure (int ret);
@@ -828,7 +828,7 @@ class Camera:public rts2core::ScriptDevice
 		 * CCDs with multiple data channels.
 		 */
 		void createDataChannels ()
-		{ 
+		{
 			createValue (dataChannels, "DATA_CHANNELS", "total number of data channels", true);
 			createValue (channels, "CHAN", "channels on/off", true, RTS2_DT_ONOFF | RTS2_VALUE_WRITABLE | RTS2_FITS_HEADERS, CAM_WORKING);
 		}
@@ -951,7 +951,7 @@ class Camera:public rts2core::ScriptDevice
 
 		int getCamFilterNum () { return camFilterVal->getValueInteger (); }
 
-		void setFilterWorking (bool working) { getCondValue (camFilterVal)->setStateCondition (working ? CAM_WORKING : CAM_EXPOSING); } 
+		void setFilterWorking (bool working) { getCondValue (camFilterVal)->setStateCondition (working ? CAM_WORKING : CAM_EXPOSING); }
 
 		/**
 		 * Mark start time of physical chip readout.
@@ -1165,7 +1165,7 @@ class Camera:public rts2core::ScriptDevice
 			double center_max = centerCutLevel->getValueDouble ();
 			double center_avg = 0;
 			int center_npix = 0;
-			
+
 			x -= getUsedX ();
 			y -= getUsedY ();
 
@@ -1322,7 +1322,7 @@ class Camera:public rts2core::ScriptDevice
 
 		std::map <std::string, double> filterOffsets;
 
-		// mode of rounding binned 
+		// mode of rounding binned
 		//-1 - ceil
 		//0 round
 		//1 floor
@@ -1332,7 +1332,7 @@ class Camera:public rts2core::ScriptDevice
 			switch (binningRounding)
 			{
 				case CEIL:
-					return (int) (ceil (n)); 
+					return (int) (ceil (n));
 				case FLOOR:
 					return (int) (floor (n));
 				case ROUND:

--- a/include/command.h
+++ b/include/command.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Command classes.
  * Copyright (C) 2003-2007 Petr Kubanek <petr@kubanek.net>
  *
@@ -96,12 +96,12 @@
 
 /**
  * Move to MPEC one line element position. @ingroup RTS2Command
- */ 
+ */
 #define COMMAND_TELD_MOVE_MPEC  "move_mpec"
 
 /**
  * Move to TLE two line elements. @ingroup RTS2Command
- */ 
+ */
 #define COMMAND_TELD_MOVE_TLE   "move_tle"
 
 /**
@@ -119,7 +119,7 @@
  *  - peek 1:20 -85:21
  *  - peek 1:20:00 -85:21
  *  - peek 20 -85.35
- */ 
+ */
 #define COMMAND_TELD_PEEK       "peek"
 
 /**
@@ -907,7 +907,7 @@ class CommandStatusInfo:public Command
 	public:
 		CommandStatusInfo (Block * master, Connection * _control_conn);
 		virtual int commandReturnOK (Connection * conn);
-		virtual int commandReturnFailed (Connection * conn);
+		virtual int commandReturnFailed (int status, Connection * conn);
 
 		const char * getCentralName()
 		{

--- a/include/objectcheck.h
+++ b/include/objectcheck.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Check if object is above horizon.
  * Copyright (C) 2003-2015 Petr Kubanek <petr@kubanek.net>
  *
@@ -38,7 +38,7 @@ class HorizonEntry
 		}
 };
 
-typedef std::vector < struct HorizonEntry > horizon_t;
+typedef std::vector < class HorizonEntry > horizon_t;
 
 /**
  * Class for checking, whenewer observation target is correct or no.

--- a/include/rts2db/simbadtargetdb.h
+++ b/include/rts2db/simbadtargetdb.h
@@ -42,7 +42,7 @@ class SimbadTargetDb: public ConstTarget, public rts2core::SimbadTarget
 
 		virtual void load ();
 
-		virtual void printExtra (Rts2InfoValStream & _os);
+		virtual void printExtra (Rts2InfoValStream & _os, double JD);
 };
 
 }

--- a/include/rts2script/execcli.h
+++ b/include/rts2script/execcli.h
@@ -132,7 +132,7 @@ class DevClientCameraExec:public rts2image::DevClientCameraImage, public DevScri
 
 		int imgCount;
 
-		virtual void startTarget ();
+		virtual void startTarget (bool callScriptEnds = true);
 
 		virtual int getNextCommand ();
 

--- a/lib/rts2/camd.cpp
+++ b/lib/rts2/camd.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Basic camera daemon
  * Copyright (C) 2001-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -594,7 +594,7 @@ Camera::~Camera ()
 
 	delete[] dataBuffers;
 	delete[] dataWritten;
-	
+
 	delete[] modeCount;
 }
 
@@ -631,7 +631,7 @@ rts2core::DevClient *Camera::createOtherType (rts2core::Connection * conn, int o
 	return rts2core::ScriptDevice::createOtherType (conn, other_device_type);
 }
 
-void Camera::checkQueChanges (int fakeState)
+void Camera::checkQueChanges (rts2_status_t fakeState)
 {
 	// don't check values changes if there are qued exposures and exposure is still running
 	if (quedExpNumber->getValueInteger () > 0 && (fakeState & (CAM_EXPOSING | CAM_READING)))
@@ -1078,7 +1078,7 @@ int Camera::sendReadoutData (char *data, size_t dataSize, int chan)
 
 	if (currentImageTransfer == SHARED)
 		sharedData->dataWritten (chan, dataSize);
-	
+
 	dataWritten[chan] += dataSize;
 
 	if (exposureConn && currentImageTransfer == TCPIP)

--- a/lib/rts2/command.cpp
+++ b/lib/rts2/command.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Command classes.
  * Copyright (C) 2003-2007 Petr Kubanek <petr@kubanek.net>
  *
@@ -702,7 +702,7 @@ int CommandStatusInfo::commandReturnOK (Connection * conn)
 	return Command::commandReturnOK (conn);
 }
 
-int CommandStatusInfo::commandReturnFailed (Connection * conn)
+int CommandStatusInfo::commandReturnFailed (int status, Connection * conn)
 {
 	if (control_conn)
 		control_conn->updateStatusWait (conn);

--- a/lib/rts2db/simbadtargetdb.cpp
+++ b/lib/rts2db/simbadtargetdb.cpp
@@ -40,9 +40,9 @@ void SimbadTargetDb::load ()
 	setPosition (pos.ra, pos.dec);
 }
 
-void SimbadTargetDb::printExtra (Rts2InfoValStream & _ivs)
+void SimbadTargetDb::printExtra (Rts2InfoValStream & _ivs, double JD)
 {
-	ConstTarget::printExtra (_ivs, ln_get_julian_from_sys ());
+	ConstTarget::printExtra (_ivs, JD);
 
 	if (_ivs.getStream ())
 	{

--- a/lib/rts2script/execcli.cpp
+++ b/lib/rts2script/execcli.cpp
@@ -112,10 +112,10 @@ void DevClientCameraExec::postEvent (rts2core::Event * event)
 		nextCommand ();
 }
 
-void DevClientCameraExec::startTarget ()
+void DevClientCameraExec::startTarget (bool callScriptEnds)
 {
 	cmdConns.clear ();
-	DevScript::startTarget ();
+	DevScript::startTarget (callScriptEnds);
 }
 
 int DevClientCameraExec::getNextCommand ()

--- a/src/plan/scriptexec.cpp
+++ b/src/plan/scriptexec.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Simple script executor.
  * Copyright (C) 2007,2009 Petr Kubanek <petr@kubanek.net>
  *
@@ -69,10 +69,10 @@ class ClientCameraScript:public rts2script::DevClientCameraExec
 
 		virtual void postEvent (rts2core::Event *event);
 		virtual imageProceRes processImage (Image * image);
-	
+
 	protected:
-		virtual void startTarget (bool b = false);
-	
+		virtual void startTarget (bool callScriptEnds = true);
+
 	private:
 		int totalExp;
 		int currentExp;
@@ -80,9 +80,9 @@ class ClientCameraScript:public rts2script::DevClientCameraExec
 		std::string obsstatus ();
 };
 
-void ClientCameraScript::startTarget (bool b)
+void ClientCameraScript::startTarget (bool callScriptEnds)
 {
-	rts2script::DevScript::startTarget (b);
+	rts2script::DevScript::startTarget (callScriptEnds);
 	rts2script::ScriptPtr sc = getScript ();
 	if (sc.get () != NULL)
 		totalExp = sc->getExpectedImages ();


### PR DESCRIPTION
Several of derived classes have methods with signatures different from base virtual ones, for no obvious reason. Seems they will not be called as a result, that may lead to logic bugs  somewhere.
Petr, please check whether these changes were intended, or just a mistakes