### PR TITLE
Improvements to rts2-xfocusc and dummy camera driver

### DIFF
--- a/include/rts2fits/image.h
+++ b/include/rts2fits/image.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Class which represents image.
  * Copyright (C) 2005-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -139,7 +139,7 @@ class Image:public FitsFile
 		/**
 		 * Create image for a given target.
 		 *
-		 * 
+		 *
 		 *
 		 */
 		Image (Rts2Target * currTarget, rts2core::DevClientCamera * camera, const struct timeval *in_exposureStart, const char *expand_path = NULL, bool overwrite = false);
@@ -199,7 +199,7 @@ class Image:public FitsFile
 		 * Create softlink of the image.
 		 *
 		 * @param link_name  Pathe where link will be created.
-		 * 
+		 *
 		 * @return 0 on success, otherwise returns system error code.
 		 */
 		int symlinkImage (const char *link_name);
@@ -207,8 +207,8 @@ class Image:public FitsFile
 		/**
 		 * Create softlink of the image. The location is specified as expansion string.
 		 *
-		 * @param link_ex   Path where image link will be created. Any 
-		 * 
+		 * @param link_ex   Path where image link will be created. Any
+		 *
 		 * @return 0 on success, otherwise returns system errror code.
 		 */
 		int symlinkImageExpand (std::string link_ex);
@@ -217,7 +217,7 @@ class Image:public FitsFile
 		 * Create hardlink of the image.
 		 *
 		 * @param link_name  Pathe where link will be created.
-		 * 
+		 *
 		 * @return 0 on success, otherwise returns system error code.
 		 */
 		int linkImage (const char *link_name);
@@ -225,8 +225,8 @@ class Image:public FitsFile
 		/**
 		 * Create hardlink of the image. The location is specified as expansion string.
 		 *
-		 * @param link_ex   Path where image link will be created. Any 
-		 * 
+		 * @param link_ex   Path where image link will be created. Any
+		 *
 		 * @return 0 on success, otherwise returns system errror code.
 		 */
 		int linkImageExpand (std::string link_ex);
@@ -279,7 +279,7 @@ class Image:public FitsFile
 		/**
 		 * Build channel histogram.
 		 *
-		 * @param chan      channel number 
+		 * @param chan      channel number
 		 * @param histogram array for calculated histogram
 		 * @param nbins     number of histogram bins
 		 */
@@ -302,8 +302,9 @@ class Image:public FitsFile
 
 		void getChannelGrayscaleImage (int _dataType, int chan, unsigned char * &buf, float quantiles, size_t offset);
 
-
 		template <typename bt, typename dt> void getChannelPseudocolourByteBuffer (int chan, bt * &buf, bt black, dt low, dt high, long s, size_t offset, bool invert_y, int colourVariant = PSEUDOCOLOUR_VARIANT_BLUE);
+
+		template <typename dt> void getChannelQuantiles (int chan, dt minval, dt mval, float quantiles, dt * low_ptr, dt * high_ptr);
 
 		/**
 		 * Returns image pseudocolour buffer. Black have value equal to black parameter, white is 0.
@@ -542,7 +543,7 @@ class Image:public FitsFile
 		int getError (double &eRa, double &eDec, double &eRad);
 
 		/**
-		 * Increase WCS value 
+		 * Increase WCS value
 		 */
 		void addWcs (double delta, int i)
 		{
@@ -608,9 +609,9 @@ class Image:public FitsFile
 		/**
 		 * Retrieves from FITS headers best raw mount coordinates.
 		 *
-		 * Those are taken from U_TELRA and U_TELDEC keywords, or computed from 
-		 * TELRA, TELDEC and MNT_FLIP values, which will not give real HW position 
-		 * (we cannot distinguish between 360deg multiples), still it should be 
+		 * Those are taken from U_TELRA and U_TELDEC keywords, or computed from
+		 * TELRA, TELDEC and MNT_FLIP values, which will not give real HW position
+		 * (we cannot distinguish between 360deg multiples), still it should be
 		 * acceptable for most cases.
 		 * Needed for TP model computations.
 		 */
@@ -737,7 +738,7 @@ class Image:public FitsFile
 
 		// if write RTS2 extended values
 		bool writeRTS2Values;
-	
+
 		int targetId;
 		int targetIdSel;
 		char targetType;
@@ -751,7 +752,7 @@ class Image:public FitsFile
 		float exposureLength;
 
 		std::string oldImageName;
-		
+
 		int createImage (char *in_filename, bool _overwrite = false);
 		int createImage (std::string in_filename, bool _overwrite = false);
 

--- a/lib/rts2fits/image.cpp
+++ b/lib/rts2fits/image.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Class which represents image.
  * Copyright (C) 2005-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -73,7 +73,7 @@ void Image::initData ()
 	verbose = true;
 
 	templateDeviceName = NULL;
-	
+
 	setFileName (NULL);
 	setFitsFile (NULL);
 	targetId = -1;
@@ -137,7 +137,7 @@ Image::Image (Image * in_image):FitsFile (in_image)
 	templateDeviceName = NULL;
 
 	exposureLength = in_image->exposureLength;
-	
+
 	channels = in_image->channels;
 	dataType = in_image->dataType;
 	in_image->channels.clear ();
@@ -399,7 +399,10 @@ int Image::createImage (bool _overwrite)
 	// add history
 	writeHistory ("Created with RTS2 version " RTS2_VERSION " build on " __DATE__ " " __TIME__ ".");
 
-	logStream (MESSAGE_DEBUG) << "creating image " << getFileName () << sendLog;
+	if (isMemImage ())
+		logStream (MESSAGE_DEBUG) << "creating in-memory image" << sendLog;
+	else
+		logStream (MESSAGE_DEBUG) << "creating image " << getFileName () << sendLog;
 
 	flags = IMAGE_SAVE;
 	return 0;
@@ -916,7 +919,7 @@ void Image::writeWCS (double mods[NUM_WCS_VALUES])
 				v = v / mods[i + 2] + mods[i];
 			else
 				v += mods[i];
-				
+
 			setValue (multiWCS (wcs_names[i], wcs_multi_rotang) , v, wcs_desc[i]);
 		}
 	}
@@ -1167,7 +1170,7 @@ template <typename bt, typename dt> void Image::getChannelGrayscaleByteBuffer (i
 {
 	if (buf == NULL)
 		buf = new bt[s];
-	
+
 	bt *k = buf;
 
 	if (invert_y)
@@ -1305,7 +1308,7 @@ template <typename bt, typename dt> void Image::getChannelPseudocolourByteBuffer
 {
 	if (buf == NULL)
 		buf = new bt[3 * s];
-	
+
 	double n;
 	bt nR, nG, nB;
 
@@ -1548,7 +1551,7 @@ Magick::Image *Image::getMagickImage (const char *label, float quantiles, int ch
 				getChannelGrayscaleImage (dataType, chan, buf, quantiles, 0);
 			else
 				getChannelPseudocolourImage (dataType, chan, buf, quantiles, 0, colourVariant);
-				
+
 		  	// single channel
 			tw = getChannelWidth (chan);
 			th = getChannelHeight (chan);
@@ -1637,7 +1640,7 @@ Magick::Image *Image::getMagickImage (const char *label, float quantiles, int ch
 
 				if ((*iter)->getHeight () > lw)
 				  	lw = (*iter)->getHeight ();
-				loff -= (*iter)->getWidth ();	
+				loff -= (*iter)->getWidth ();
 			}
 
 		}
@@ -1683,7 +1686,7 @@ void Image::writeLabel (Magick::Image *mimage, int x, int y, unsigned int fs, co
 void Image::writeAsJPEG (std::string expand_str, double zoom, const char *label, float quantiles , int chan, int colourVariant)
 {
 	std::string new_filename = expandPath (expand_str);
-	
+
 	int ret = mkpath (new_filename.c_str (), 0777);
 	if (ret)
 	{
@@ -2093,7 +2096,7 @@ template <typename bt, typename dt> const bt * scaleData (dt * data, size_t nump
 			break;
 		case SCALING_POW:
 			doscaling(d*=d)
-			break; 
+			break;
 		case SCALING_SQRT:
 			doscaling(d=sqrt (d))
 			break;
@@ -2451,7 +2454,7 @@ void Image::prepareArrayData (const std::string sname, rts2core::Connection *con
 	}
 	// otherwise, prepare data structure to be written
 	std::map <int, TableData *>::iterator ai = arrayGroups.find (val->getWriteGroup ());
-	
+
 	if (ai == arrayGroups.end ())
 	{
 		rts2core::Value *infoTime = conn->getValue (RTS2_VALUE_INFOTIME);

--- a/lib/rts2fits/image.cpp
+++ b/lib/rts2fits/image.cpp
@@ -1216,6 +1216,7 @@ template <typename bt, typename dt> void Image::getChannelGrayscaleByteBuffer (i
 }
 
 
+
 template <typename bt, typename dt> void Image::getChannelGrayscaleBuffer (int chan, bt * &buf, bt black, dt minval, dt mval, float quantiles, size_t offset, bool invert_y)
 {
 	long hist[65536];
@@ -1442,8 +1443,7 @@ template <typename bt, typename dt> void Image::getChannelPseudocolourByteBuffer
 	}
 }
 
-
-template <typename bt, typename dt> void Image::getChannelPseudocolourBuffer (int chan, bt * &buf, bt black, dt minval, dt mval, float quantiles, size_t offset, bool invert_y, int colourVariant)
+template <typename dt> void Image::getChannelQuantiles (int chan, dt minval, dt mval, float quantiles, dt * low_ptr, dt * high_ptr)
 {
 	long hist[65536];
 	getChannelHistogram (chan, hist, 65536);
@@ -1489,9 +1489,27 @@ template <typename bt, typename dt> void Image::getChannelPseudocolourBuffer (in
 		}
 	}
 
-	getChannelPseudocolourByteBuffer (chan, buf, black, low, high, s, offset, invert_y, colourVariant);
+	if (low_ptr)
+		*low_ptr = low;
+
+	if (high_ptr)
+		*high_ptr = high;
 }
 
+// Instantiate it for ints for use outside librts2image
+template void Image::getChannelQuantiles (int , int , int , float, int * , int * );
+
+template <typename bt, typename dt> void Image::getChannelPseudocolourBuffer (int chan, bt * &buf, bt black, dt minval, dt mval, float quantiles, size_t offset, bool invert_y, int colourVariant)
+{
+	dt low = minval;
+	dt high = minval;
+
+	long s = getChannelNPixels (chan);
+
+	getChannelQuantiles (chan, low, high, quantiles, &low, &high);
+
+	getChannelPseudocolourByteBuffer (chan, buf, black, low, high, s, offset, invert_y, colourVariant);
+}
 
 void Image::getChannelPseudocolourImage (int _dataType, int chan, unsigned char * &buf, float quantiles, size_t offset, int colourVariant)
 {

--- a/src/focusc/xfitsimage.cpp
+++ b/src/focusc/xfitsimage.cpp
@@ -452,9 +452,6 @@ void XFitsImage::drawImage (rts2image::Image * image, int chan, Display * _displ
 	// get cuts
 	double sigma;
 	median = classical_median (iP, image->getDataType (), iW * iH, &sigma);
-	// low = (int) (median - 3 * sigma);
-	// high = (int) (median + 5 * sigma);
-
 	image->getChannelQuantiles (chan, (int) INT_MIN, (int) INT_MAX, quantiles, &low, &high);
 
 	// clear progress indicator
@@ -801,7 +798,7 @@ void XFitsImage::buildWindow ()
 	gc = XCreateGC (display, pixmap, 0, &gvc);
 	XSelectInput (display, window, KeyPressMask | ButtonPressMask | ExposureMask | PointerMotionMask);
 	XMapRaised (display, window);
-	XFlush(display);
+	XFlush (display);
 
 	cameraName = new char[strlen (connection->getName ()) + 1];
 	strcpy (cameraName, connection->getName ());

--- a/src/focusc/xfitsimage.cpp
+++ b/src/focusc/xfitsimage.cpp
@@ -124,6 +124,25 @@ void XFitsImage::XeventLoop ()
 					case XK_3:
 						connection->queCommand (new rts2core::CommandChangeValue (client->getMaster (), "binning", '=', 2));
 						break;
+
+					case XK_4:
+						quantiles = 0.05;
+						break;
+					case XK_5:
+						quantiles = 0.01;
+						break;
+					case XK_6:
+						quantiles = 0.001;
+						break;
+					case XK_7:
+						quantiles = 0.0001;
+						break;
+
+					case XK_8:
+					case XK_m:
+						setColourVariant ((colourVariant + 1) % 14);
+						break;
+
 					case XK_9:
 						master->GoNine = !master->GoNine;
 						break;
@@ -219,6 +238,9 @@ void XFitsImage::XeventLoop ()
 					case XK_minus:
 					case XK_KP_Subtract:
 						master->zoom = master->zoom / 2.0;
+						break;
+					case XK_0:
+						master->zoom = 1;
 						break;
 					default:
 						break;
@@ -625,14 +647,11 @@ double XFitsImage::classical_median (void *q, int16_t dataType, int n, double *s
 	return M;
 }
 
-void XFitsImage::buildWindow ()
+void XFitsImage::setColourVariant (int _i)
 {
-	XTextProperty window_title;
-	char *cameraName;
-
 	Status ret;
 
-	colormap = DefaultColormap (display, DefaultScreen (display));
+	colourVariant = _i;
 
 	// allocate colormap..
 	for (int i = 0; i < 256; i++)
@@ -732,6 +751,11 @@ void XFitsImage::buildWindow ()
 				break;
 			default:
 				logStream (MESSAGE_ERROR) << "Unknown colourVariant" << colourVariant << sendLog;
+
+				n = 255.0 * double (pix - low) / double (high - low);
+				nR = n;
+				nG = nR;
+				nB = nR;
 		}
 
 		rgb[i].red = 256 * nR;
@@ -760,6 +784,16 @@ void XFitsImage::buildWindow ()
 	ret = XAllocColor (display, colormap, &rgb[257]);
 	if (!ret)
 		throw rts2core::Error ("cannot allocate greencolor");
+}
+
+void XFitsImage::buildWindow ()
+{
+	XTextProperty window_title;
+	char *cameraName;
+
+	colormap = DefaultColormap (display, DefaultScreen (display));
+
+	setColourVariant (colourVariant);
 
 	window = XCreateWindow (display, DefaultRootWindow (display), 0, 0, 100, 100, 0, depth, InputOutput, visual, 0, &xswa);
 	pixmap = XCreatePixmap (display, window, windowWidth, windowHeight, depth);

--- a/src/focusc/xfitsimage.h
+++ b/src/focusc/xfitsimage.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Display RTS2 (and FITS images) in separate window.
  * Copyright (C) 2012 Petr Kubanek, Institute of Physics <kubanek@fzu.cz>
  *
@@ -43,7 +43,7 @@ class Marker
 class XFitsImage
 {
 	public:
-		XFitsImage (rts2core::Connection *_connection, rts2core::DevClient *_client);
+		XFitsImage (rts2core::Connection *_connection, rts2core::DevClient *_client, float _quantiles = 0.005, int _colourVariant = PSEUDOCOLOUR_VARIANT_BLUE);
 		virtual ~XFitsImage ();
 
 		void setCrossType (int in_crossType);
@@ -61,6 +61,8 @@ class XFitsImage
 		void drawImage (rts2image::Image * image, int channel, Display * _display, Visual *_visual, int _depth, double zoom, int _crossType, bool GoNine);
 
 		int getChannelNumber () { return channelnum; }
+
+		void setColourVariant (int _i) { colourVariant = _i; }
 
 	private:
 		double classical_median (void *q, int16_t dataType, int n, double *sigma, double sf = 0.6745);
@@ -135,6 +137,12 @@ class XFitsImage
 
 		// image channel
 		int channelnum;
+
+		// colormap
+		int colourVariant;
+
+		// Quantiles
+		float quantiles;
 };
 
 #endif // __RTS2_XFITSIMAGE__

--- a/src/focusc/xfitsimage.h
+++ b/src/focusc/xfitsimage.h
@@ -143,6 +143,12 @@ class XFitsImage
 
 		// Quantiles
 		float quantiles;
+
+		// Focus position
+		int focPos;
+
+		// Exposure time
+		double expTime;
 };
 
 #endif // __RTS2_XFITSIMAGE__

--- a/src/focusc/xfitsimage.h
+++ b/src/focusc/xfitsimage.h
@@ -62,7 +62,7 @@ class XFitsImage
 
 		int getChannelNumber () { return channelnum; }
 
-		void setColourVariant (int _i) { colourVariant = _i; }
+		void setColourVariant (int _i);
 
 	private:
 		double classical_median (void *q, int16_t dataType, int n, double *sigma, double sf = 0.6745);

--- a/src/focusc/xfocusc.cpp
+++ b/src/focusc/xfocusc.cpp
@@ -100,15 +100,15 @@ XFocusClient::XFocusClient (int in_argc, char **in_argv):FocusClient (in_argc, i
 {
 	displayName = NULL;
 
-	crossType = 0;
+	crossType = 5;
 	starsType = 0;
 
 	changeVal = 15;
 	zoom = 1.0;
 	GoNine = false;
 
-	quantiles = 0.05;
-	colourVariant = PSEUDOCOLOUR_VARIANT_GREY;
+	quantiles = 0.01;
+	colourVariant = PSEUDOCOLOUR_VARIANT_BLUE;
 
 	addOption (OPT_DISPLAY, "display", 1, "name of X display");
 	addOption (OPT_STARS, "stars", 0, "draw stars over image (default to don't)");
@@ -142,21 +142,22 @@ void XFocusClient::help ()
 	Client::help ();
 	std::cout
 		<< "Keys:" << std::endl
-		<< "\t1,2,3 .. binning 1x1, 2x2, 3x3" << std::endl
-		<< "\t9     .. split screen to squares containg corners of the image and its center" << std::endl
-		<< "\tq,a   .. increase/decrease exposure by 0.01 sec" << std::endl
-		<< "\tw,s   .. increase/decrease exposure by 0.1 sec" << std::endl
-		<< "\te,d   .. increase/decrease exposure by 1 sec" << std::endl
-
-		<< "\tf     .. full frame exposure" << std::endl
-		<< "\tc     .. center (1/2x1/2 chip size) exposure" << std::endl
+		<< "\t1,2,3   .. binning 1x1, 2x2, 3x3" << std::endl
+		<< "\t4,5,6,7 .. set intensity cutoff quantiles to 0.05, 0.01, 0.001, 0.0001" << std::endl
+		<< "\t8,m     .. change display colormap" << std::endl
+		<< "\t9       .. split screen to squares containg corners of the image and its center" << std::endl
+		<< "\tq,a     .. increase/decrease exposure by 0.01 sec" << std::endl
+		<< "\tw,s     .. increase/decrease exposure by 0.1 sec" << std::endl
+		<< "\te,d     .. increase/decrease exposure by 1 sec" << std::endl
+		<< "\tf       .. full frame exposure" << std::endl
+		<< "\tc       .. center (1/2x1/2 chip size) exposure" << std::endl
 		// << "\ty     .. save FITS file" << std::endl
 		// << "\tu     .. don't save fits file" << std::endl
 		// << "\thjkl, arrows .. move (change mount position)" << std::endl
-		<< "\tx     ..  change cross type" << std::endl
-		<< "\t[,]   ..  decrease/increase focus by 100" << std::endl
-		<< "\t{,}   ..  decrease/increase focus by 100" << std::endl
-		<< "\t+-    .. change zoom" << std::endl;
+		<< "\tx       .. change cross type" << std::endl
+		<< "\t[,]     .. decrease/increase focus by 100" << std::endl
+		<< "\t{,}     .. decrease/increase focus by 10" << std::endl
+		<< "\t+,-,0   .. change zoom" << std::endl;
 }
 
 int XFocusClient::processOption (int in_opt)

--- a/src/focusc/xfocusc.cpp
+++ b/src/focusc/xfocusc.cpp
@@ -140,17 +140,22 @@ void XFocusClient::usage ()
 void XFocusClient::help ()
 {
 	Client::help ();
-	std::cout << "Keys:" << std::endl
+	std::cout
+		<< "Keys:" << std::endl
 		<< "\t1,2,3 .. binning 1x1, 2x2, 3x3" << std::endl
 		<< "\t9     .. split screen to squares containg corners of the image and its center" << std::endl
-		<< "\tq,a   .. increase/decrease exposure 0.01 sec" << std::endl
-		<< "\tw,s   .. increase/decrease exposure 0.1 sec" << std::endl
-		<< "\te,d   .. increase/decrease exposure 1 sec" << std::endl
+		<< "\tq,a   .. increase/decrease exposure by 0.01 sec" << std::endl
+		<< "\tw,s   .. increase/decrease exposure by 0.1 sec" << std::endl
+		<< "\te,d   .. increase/decrease exposure by 1 sec" << std::endl
+
 		<< "\tf     .. full frame exposure" << std::endl
 		<< "\tc     .. center (1/2x1/2 chip size) exposure" << std::endl
-		<< "\ty     .. save FITS file" << std::endl
-		<< "\tu     .. don't save fits file" << std::endl
-		<< "\thjkl, arrows .. move (change mount position)" << std::endl
+		// << "\ty     .. save FITS file" << std::endl
+		// << "\tu     .. don't save fits file" << std::endl
+		// << "\thjkl, arrows .. move (change mount position)" << std::endl
+		<< "\tx     ..  change cross type" << std::endl
+		<< "\t[,]   ..  decrease/increase focus by 100" << std::endl
+		<< "\t{,}   ..  decrease/increase focus by 100" << std::endl
 		<< "\t+-    .. change zoom" << std::endl;
 }
 
@@ -167,7 +172,7 @@ int XFocusClient::processOption (int in_opt)
 		case OPT_STARS:
 			starsType = 1;
 			break;
-		case 'X':
+		case 'x':
 			crossType = atoi (optarg);
 			break;
 		case 'Z':

--- a/src/focusc/xfocusc.cpp
+++ b/src/focusc/xfocusc.cpp
@@ -257,7 +257,5 @@ int main (int argc, char **argv)
 {
 	XFocusClient masterFocus = XFocusClient (argc, argv);
 
-	logStream (MESSAGE_DEBUG) << "creating image " << NULL << sendLog;
-
 	return masterFocus.run ();
 }

--- a/src/focusc/xfocusc.h
+++ b/src/focusc/xfocusc.h
@@ -105,12 +105,15 @@ class XFocusClientCamera:public FocusCameraClient
 		XFocusClientCamera (rts2core::Connection * in_connection, double in_change_val, XFocusClient * in_master);
 		virtual ~XFocusClientCamera ();
 
+		int getCrossType () { return crossType; }
 		void setCrossType (int in_crossType);
 
 		virtual void postEvent (rts2core::Event * event);
 
 		float quantiles;
 		int colourVariant;
+
+		XFocusClient * getMaster () { return master; }
 
 	protected:
 		virtual void cameraImageReady (rts2image::Image * image);

--- a/src/focusc/xfocusc.h
+++ b/src/focusc/xfocusc.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Take an image, display it in X window (XImage).
  * Copyright (C) 2004-2007 Petr Kubanek <petr@kubanek.net>
  * Copyright (C) 2012 Petr Kubanek, Institute of Physics <kubanek@fzu.cz>
@@ -79,6 +79,9 @@ class XFocusClient:public FocusClient
 		double zoom;
 		bool GoNine;
 
+		float quantiles;
+		int colourVariant;
+
 	private:
 		char * displayName;
 
@@ -105,6 +108,9 @@ class XFocusClientCamera:public FocusCameraClient
 		void setCrossType (int in_crossType);
 
 		virtual void postEvent (rts2core::Event * event);
+
+		float quantiles;
+		int colourVariant;
 
 	protected:
 		virtual void cameraImageReady (rts2image::Image * image);


### PR DESCRIPTION
- Generating quasi-realistic stellar fields in dummy camera driver, with simple defocusing emulation to be potentially usable for testing autofocusing scripts. 

- Usability improvements for rts2-xfocusc, including configurable (and adjustable on the fly) colormap, cutoff quantiles and overlay type, keybindings for shifting camera focus, etc. Some keybindings mentioned in the help are restored to work, others removed from help for now.