### PR TITLE
Quick fix for recent commit that broke colormapped image display in HTTPD

### DIFF
--- a/lib/rts2fits/image.cpp
+++ b/lib/rts2fits/image.cpp
@@ -1219,49 +1219,12 @@ template <typename bt, typename dt> void Image::getChannelGrayscaleByteBuffer (i
 
 template <typename bt, typename dt> void Image::getChannelGrayscaleBuffer (int chan, bt * &buf, bt black, dt minval, dt mval, float quantiles, size_t offset, bool invert_y)
 {
-	long hist[65536];
-	getChannelHistogram (chan, hist, 65536);
-
-	long psum = 0;
 	dt low = minval;
 	dt high = minval;
 
-	uint32_t i;
-
 	long s = getChannelNPixels (chan);
 
-	// find quantiles
-	for (i = 0; (dt) i < mval; i++)
-	{
-		psum += hist[i];
-		if (psum > s * quantiles)
-		{
-			low = i;
-			break;
-		}
-	}
-
-	if (low == minval)
-	{
-		low = minval;
-		high = mval;
-	}
-	else
-	{
-		for (; (dt) i < mval; i++)
-		{
-			psum += hist[i];
-			if (psum > s * (1 - quantiles))
-			{
-				high = i;
-				break;
-			}
-		}
-		if (high == minval)
-		{
-			high = mval;
-		}
-	}
+	getChannelQuantiles (chan, minval, mval, quantiles, &low, &high);
 
 	getChannelGrayscaleByteBuffer (chan, buf, black, low, high, s, offset, invert_y);
 }
@@ -1506,7 +1469,7 @@ template <typename bt, typename dt> void Image::getChannelPseudocolourBuffer (in
 
 	long s = getChannelNPixels (chan);
 
-	getChannelQuantiles (chan, low, high, quantiles, &low, &high);
+	getChannelQuantiles (chan, minval, mval, quantiles, &low, &high);
 
 	getChannelPseudocolourByteBuffer (chan, buf, black, low, high, s, offset, invert_y, colourVariant);
 }

--- a/lib/rts2fits/image.cpp
+++ b/lib/rts2fits/image.cpp
@@ -1736,7 +1736,7 @@ void Image::writeAsBlob (Magick::Blob &blob, const char * label, float quantiles
 	try
 	{
 		image = getMagickImage (label, quantiles, chan, colourVariant);
-		image->write (&blob, "jpeg");
+		image->write (&blob, "JPEG");
 		delete image;
 	}
 	catch (Magick::Exception &ex)

--- a/lib/rts2json/imgpreview.cpp
+++ b/lib/rts2json/imgpreview.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Image preview and download classes.
  * Copyright (C) 2009-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -183,8 +183,8 @@ void Previewer::form (std::ostringstream &_os, int page, int ps, int s, int c, c
 
 	if (c < 0)
 		_os << " selected";
-	
-	_os << ">All</option>";	
+
+	_os << ">All</option>";
 
 	for (int i = 0; i < CHANNELS; i++)
 	{
@@ -194,7 +194,7 @@ void Previewer::form (std::ostringstream &_os, int page, int ps, int s, int c, c
 		_os << ">" << (i + 1) << "</option>";
 	}
 
-	_os << "</select> \n" 
+	_os << "</select> \n"
 #endif
 	"Color map <select name='cv'>";
 
@@ -246,7 +246,7 @@ void JpegImageRequest::authorizedExecute (XmlRpc::XmlRpcSource *source, std::str
 
 	cacheMaxAge (CACHE_MAX_STATIC);
 
-	mimage->write (&blob, "jpeg");
+	mimage->write (&blob, "JPEG");
 	response_length = blob.length();
 	response = new char[response_length];
 	memcpy (response, blob.data(), response_length);
@@ -262,7 +262,7 @@ void JpegPreview::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 	// const char *t = params->getString ("t", "p");
 
 	const char *label = params->getString ("lb", getServer ()->getDefaultImageLabel ());
-	
+
 	std::string lb (label);
 	XmlRpc::urlencode (lb);
 	const char * label_encoded = lb.c_str ();
@@ -296,7 +296,7 @@ void JpegPreview::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 
 		cacheMaxAge (CACHE_MAX_STATIC);
 
-		mimage->write (&blob, "jpeg");
+		mimage->write (&blob, "JPEG");
 		response_length = blob.length();
 		response = new char[response_length];
 		memcpy (response, blob.data(), response_length);
@@ -322,7 +322,7 @@ void JpegPreview::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 	_os << "<p>";
 
 	preview.form (_os, pageno, prevsize, pagesiz, chan, label, quantiles, colourVariant);
-	
+
 	_os << "</p><p>";
 
 	struct dirent **namelist;
@@ -396,7 +396,7 @@ void JpegPreview::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 	}
 
 	free (namelist);
-			
+
 	// print pages..
 	_os << "</p><p>Page ";
 	for (i = 1; i <= in / pagesiz; i++)
@@ -404,7 +404,7 @@ void JpegPreview::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 	if (in % pagesiz)
 	 	preview.pageLink (_os, i, pagesiz, prevsize, label_encoded, i == pageno, quantiles, chan, colourVariant);
 	_os << "</p>";
-	
+
 	printFooter (_os);
 
 	response_type = "text/html";
@@ -426,7 +426,7 @@ void FitsImageRequest::authorizedExecute (XmlRpc::XmlRpcSource *source, std::str
 	struct stat st;
 	if (fstat (f, &st) == -1)
 		throw XmlRpc::XmlRpcException ("Cannot get file properties");
-	
+
 	response_length = st.st_size;
 	response = new char[response_length];
 	ssize_t ret;

--- a/lib/rts2json/nightreq.cpp
+++ b/lib/rts2json/nightreq.cpp
@@ -45,7 +45,7 @@ void Night::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string path, X
 	int year = -1;
 	int month = -1;
 	int day = -1;
-	
+
 	enum {NONE, IMAGES, API, ALT, ALTAZ} action = NONE;
 
 	switch (vals.size ())
@@ -211,7 +211,7 @@ void Night::printAlt (int year, int month, int day, XmlRpc::HttpParams *params, 
 	ap.getPlot (from, end, &is, &mimage);
 
 	Magick::Blob blob;
-	mimage.write (&blob, "jpeg");
+	mimage.write (&blob, "JPEG");
 
 	response_length = blob.length();
 	response = new char[response_length];
@@ -252,7 +252,7 @@ void Night::printAltAz (int year, int month, int day, XmlRpc::HttpParams *params
 	}
 
 	Magick::Blob blob;
-	altaz.write (&blob, "jpeg");
+	altaz.write (&blob, "JPEG");
 
 	response_length = blob.length();
 	response = new char[response_length];
@@ -371,7 +371,7 @@ void Night::printTable (int year, int month, int day, char* &response, size_t &r
 	_os << "</p><p><div id='observations'>Loading..</div>";
 
 	_os << "</p>";
-	
+
 	printFooter (_os);
 
 	response_length = _os.str ().length ();

--- a/lib/rts2json/targetreq.cpp
+++ b/lib/rts2json/targetreq.cpp
@@ -82,7 +82,7 @@ void Targets::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string path,
 				throw rts2core::Error ("Target id < 0");
 
 			tar = createTarget (tar_id, rts2core::Configuration::instance ()->getObserver (), rts2core::Configuration::instance ()->getObservatoryAltitude ());
-		}	
+		}
 		if (tar == NULL)
 			throw rts2core::Error ("Cannot find target with given ID");
 
@@ -237,7 +237,7 @@ void Targets::listTargets (XmlRpc::HttpParams *params, const char* &response_typ
 	"<input type='submit' value='Plot target altitude' name='plot'/> (please select at least one target to plot something interesting)\n"
 	"</form>\n";
 #endif // RTS2_HAVE_LIBJPEG
-	
+
 	printFooter (_os);
 
 	response_type = "text/html";
@@ -255,10 +255,10 @@ void Targets::processForm (XmlRpc::HttpParams *params, const char* &response_typ
 
 		AltPlot ap (params->getInteger ("w", 800), params->getInteger ("h", 600));
 		Magick::Geometry size (params->getInteger ("w", 800), params->getInteger ("h", 600));
-	
+
 		double from = params->getDouble ("from", 0);
 		double to = params->getDouble ("to", 0);
-	
+
 		if (from < 0 && to == 0)
 		{
 			// just fr specified - from
@@ -283,13 +283,13 @@ void Targets::processForm (XmlRpc::HttpParams *params, const char* &response_typ
 
 		rts2db::TargetSet ts = rts2db::TargetSet ();
 		ts.load (ti);
-	
+
 		Magick::Image mimage (size, "white");
 		ap.getPlot (from, to, &ts, &mimage);
-	
+
 		Magick::Blob blob;
-		mimage.write (&blob, "jpeg");
-	
+		mimage.write (&blob, "JPEG");
+
 		response_length = blob.length();
 		response = new char[response_length];
 		memcpy (response, blob.data(), response_length);
@@ -361,7 +361,7 @@ void Targets::processAPI (XmlRpc::HttpParams *params, const char* &response_type
 			_os << -1;
 		else
 			_os << tar->getBonus ();
-		
+
 		_os << "," << tar->getTargetEnabled ()
 			<< ",\"" << tar->getViolatedConstraints (JD)
 			<< "\",\"" << tar->getSatisfiedConstraints (JD)
@@ -406,10 +406,10 @@ void Targets::callAPI (rts2db::Target *tar, XmlRpc::HttpParams *params, const ch
 		tar->getAltAz (&hp, JD);
 		os << std::fixed << "{\"name\":\"" << tar->getTargetName ()
 			<< "\",\"id\":" << tar->getTargetID ()
-			<< ",\"ra\":" << tp.ra << ",\"dec\":" << tp.dec 
+			<< ",\"ra\":" << tp.ra << ",\"dec\":" << tp.dec
 			<< ",\"alt\":" << hp.alt << ",\"az\":" << hp.az
 			<< ",\"airmass\":" << tar->getAirmass (JD) << ",\"satisfied\":";
-		
+
 		tar->getSatisfiedConstraints (JD).printJSON (os);
 
 		os << ",\"violated\":";
@@ -423,7 +423,7 @@ void Targets::callAPI (rts2db::Target *tar, XmlRpc::HttpParams *params, const ch
 
 		returnJSON (os, response_type, response, response_length);
 		return;
-	}	
+	}
 	e = params->getString ("e", NULL);
 	if (e != NULL)
 	{
@@ -527,7 +527,7 @@ void Targets::callTargetAPI (rts2db::Target *tar, const std::string &req, XmlRpc
 		{
 			if (iter != os.begin ())
 				_os << ",";
-			_os << "[" << iter->getObsId () << "," 
+			_os << "[" << iter->getObsId () << ","
 				<< iter->getObsRa () << ","
 				<< iter->getObsDec () << ",\""
 				<< iter->getObsSlew () << "\",\""
@@ -567,7 +567,7 @@ void Targets::callTargetAPI (rts2db::Target *tar, const std::string &req, XmlRpc
 			tar->getPosition (&equ, JDstart);
 			struct ln_hrz_posn hrz;
 			tar->getAltAz (&hrz, JDstart);
-			_os << "[" << iter->getPlanId () << ",\"" 
+			_os << "[" << iter->getPlanId () << ",\""
 				<< iter->getPlanStart () << "\",\""
 				<< iter->getPlanEnd () << "\","
 				<< equ.ra << "," << equ.dec << ","
@@ -713,7 +713,7 @@ void Targets::printTarget (rts2db::Target *tar, const char* &response_type, char
 
 	// javascript to send requests..
 	double JD = ln_get_julian_from_sys ();
-	
+
 	_os << "<div id='info' class='b_left'><table><tr><td>Name</td><td>" << tar->getTargetName () << "</td></tr>"
 		"<tr><td>RA DEC</td><td>" << LibnovaRaDec (&tradec) << "</td></tr>"
 		"<tr><td>ALT AZ</td><td><span id='altaz'/></td></tr>"
@@ -735,17 +735,17 @@ void Targets::printTarget (rts2db::Target *tar, const char* &response_type, char
 
 	if (hasPermission (PERMISSIONS_TARGET_NEXT))
 		_os << "<tr><td cellspan='2'><button type='button' onclick='tar_next();'>next target</button><div id='next' style='display:none'>nothing</div></td></tr>";
-	
+
 	if (hasPermission (PERMISSIONS_TARGET_NOW))
 		_os << "<tr><td cellspan='2'><button type='button' onclick='tar_now();'>now (immediate) target</button><div id='now' style='display:none'>nothing</div></td></tr>";
-	
+
 	if (hasPermission (PERMISSIONS_TARGET_ENABLE))
 		_os << "<tr><td>Enabled</td><td><input type='checkbox' id='tar_enable' onclick='tar_enable (this.checked);' checked='" << (tar->getTargetEnabled () ? "yes" : "no") << "'/></td></tr>";
 	else
 	  	_os << "<tr><td>Enabled</td><td>" << (tar->getTargetEnabled () ? "yes" : "no") << "</td></tr>";
 
 	_os << "</table></div>";
-	
+
 	if (hasPermission (PERMISSIONS_TARGET_SCRIPTEDIT))
 	{
 		_os << "<div id='scripteditor'i class='b_right'>";
@@ -775,7 +775,7 @@ void Targets::printTarget (rts2db::Target *tar, const char* &response_type, char
 			_os << "<option value='" << n << "'>" << n << "</option>";
 			camiter++;
 		}
-	
+
 		_os << "</select></div>"
 			"<div><button type='button' onclick='updateScript();'>Update</button></div>"
 			"<div id='scriptlog'></div>"
@@ -820,7 +820,7 @@ void Targets::printTarget (rts2db::Target *tar, const char* &response_type, char
 void Targets::printTargetInfo (rts2db::Target *tar, const char* &response_type, char* &response, size_t &response_length)
 {
 	std::ostringstream _os;
-	
+
 	printHeader (_os, (std::string ("Target ") + tar->getTargetName ()).c_str ());
 
 	printTargetHeader (tar->getTargetID (), "details", _os);
@@ -832,7 +832,7 @@ void Targets::printTargetInfo (rts2db::Target *tar, const char* &response_type, 
 	tar->sendInfo (ivos, JD, 0);
 
 	_os << "</pre>";
-	
+
 	printFooter (_os);
 
 	response_type = "text/html";
@@ -844,7 +844,7 @@ void Targets::printTargetInfo (rts2db::Target *tar, const char* &response_type, 
 void Targets::printTargetStat (rts2db::Target *tar, const char* &response_type, char* &response, size_t &response_length)
 {
 	std::ostringstream _os;
-	
+
 	printHeader (_os, (std::string ("Target ") + tar->getTargetName ()).c_str ());
 
 	printTargetHeader (tar->getTargetID (), "stat", _os);
@@ -894,13 +894,13 @@ void Targets::printTargetImages (rts2db::Target *tar, XmlRpc::HttpParams *params
 	printHeader (_os, (std::string ("Images of target ") + tar->getTargetName ()).c_str (), preview.style ());
 
 	printTargetHeader (tar->getTargetID (), "images", _os);
-	
+
 	preview.script (_os, label_encoded, quantiles, chan, colourVariant);
-		
+
 	_os << "<p>";
 
 	preview.form (_os, pageno, prevsize, pagesiz, chan, label, quantiles, colourVariant);
-	
+
 	_os << "</p><p>";
 
 	rts2db::ImageSetTarget is = rts2db::ImageSetTarget (tar->getTargetID ());
@@ -929,13 +929,13 @@ void Targets::printTargetImages (rts2db::Target *tar, XmlRpc::HttpParams *params
 
 	_os << "</p><p>Page ";
 	int i;
-	
+
 	for (i = 1; i <= ((int) is.size ()) / pagesiz; i++)
 	 	preview.pageLink (_os, i, pagesiz, prevsize, label_encoded, i == pageno, quantiles, chan, colourVariant);
 	if (in % pagesiz)
 	 	preview.pageLink (_os, i, pagesiz, prevsize, label_encoded, i == pageno, quantiles, chan, colourVariant);
 	_os << "</p>";
-	
+
 	printFooter (_os);
 
 	response_type = "text/html";
@@ -1023,7 +1023,7 @@ void Targets::plotTarget (rts2db::Target *tar, XmlRpc::HttpParams *params, const
 	ap.getPlot (from, to, tar, &mimage);
 
 	Magick::Blob blob;
-	mimage.write (&blob, "jpeg");
+	mimage.write (&blob, "JPEG");
 
 	response_length = blob.length();
 	response = new char[response_length];

--- a/src/httpd/augerreq.cpp
+++ b/src/httpd/augerreq.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Classes for answers to HTTP requests.
  * Copyright (C) 2009 Petr Kubanek <petr@kubanek.net>
  *
@@ -45,7 +45,7 @@ void Auger::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string path, X
 		case 4:
 			// assumes that all previous are OK, get just target
 			printTarget (atoi (vals[3].c_str ()), response_type, response, response_length);
-			break;			
+			break;
 		case 3:
 			day = atoi (vals[2].c_str ());
 		case 2:
@@ -97,7 +97,7 @@ void Auger::printTarget (int auger_id, const char* &response_type, char* &respon
 	}
 
 	Magick::Blob blob;
-	aa.write (&blob, "jpeg");
+	aa.write (&blob, "JPEG");
 
 	response_type = "image/jpeg";
 
@@ -169,7 +169,7 @@ void Auger::printTable (int year, int month, int day, char* &response, size_t &r
 	}
 
 	_os << "</table>";
-	
+
 	printFooter (_os);
 
 	response_length = _os.str ().length ();

--- a/src/httpd/graphreq.cpp
+++ b/src/httpd/graphreq.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Classes to plot graph interface.
  * Copyright (C) 2009-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -136,7 +136,7 @@ void CurrentPosition::authorizedExecute (XmlRpc::XmlRpcSource *source, std::stri
 #endif /* RTS2_HAVE_PGSQL */
 
 	Magick::Blob blob;
-	altaz.write (&blob, "jpeg");
+	altaz.write (&blob, "JPEG");
 
 	response_type = "image/jpeg";
 
@@ -171,10 +171,10 @@ void AltAzTarget::authorizedExecute (XmlRpc::XmlRpcSource *source, std::string p
 		if (hrz.alt > -2)
 			altaz.plotCross (&hrz, (*iter).second->getTargetName ());
 	}
-	
+
 	// write image to blob as JPEG
 	Magick::Blob blob;
-	altaz.write (&blob, "jpeg");
+	altaz.write (&blob, "JPEG");
 
 	// set MIME response type
 	response_type = "image/jpeg";
@@ -309,7 +309,7 @@ void Graph::plotValue (rts2db::Recval *rv, double from, double to, XmlRpc::HttpP
 		default:
 			pt = rts2json::PLOTTYPE_AUTO;
 	}
-	
+
 	Magick::Geometry size (params->getInteger ("w", 800), params->getInteger ("h", 600));
 
 	from = params->getDate ("from", from);
@@ -332,7 +332,7 @@ void Graph::plotValue (rts2db::Recval *rv, double from, double to, XmlRpc::HttpP
 	vp.getPlot (from, to, &mimage, pt, params->getInteger ("lw", 3), params->getInteger ("sh", 3), params->getBoolean ("pn", true), params->getBoolean ("ps", true), params->getBoolean ("l", true));
 
 	Magick::Blob blob;
-	mimage.write (&blob, "jpeg");
+	mimage.write (&blob, "JPEG");
 
 	response_length = blob.length();
 	response = new char[response_length];


### PR DESCRIPTION
Also, change "jpeg" to "JPEG" as GraphicsMagick image format name, as it seems lowercase is not working on some setups.