### PR TITLE
Fixes for telescope astrometric corrections not being applied or applied incorrectly

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -686,7 +686,7 @@ class CommandChange:public Command
 class CommandCorrect:public Command
 {
 	public:
-		CommandCorrect (Block * _master, int corr_mark, int corr_img, int img_id, double ra_corr, double dec_corr, double pos_err);
+		CommandCorrect (Block * _master, int corr_mark, int corr_img, int corr_obs, int img_id, int obs_id, double ra_corr, double dec_corr, double pos_err);
 };
 
 class CommandStartGuide:public Command

--- a/include/teld.h
+++ b/include/teld.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Telescope control daemon.
  * Copyright (C) 2003-2009 Petr Kubanek <petr@kubanek.net>
  *
@@ -79,7 +79,7 @@ namespace rts2teld
  * Please see startResync() documentation for functions available to
  * retrieve various coordinates. startResync is the routine which is called
  * each time coordinates written as target should be matched to physical
- * telescope coordinates. Using various methods in the class, driver can 
+ * telescope coordinates. Using various methods in the class, driver can
  * get various coordinates which will be put to telescope.
  *
  * @author Petr Kubanek <petr@kubanek.net>
@@ -203,7 +203,7 @@ class Telescope:public rts2core::Device
 		}
 
 		void setModel (rts2telmodel::TelModel *_model) { model = _model; calModel->setValueBool (model != NULL); }
-		
+
 	protected:
 		/**
 		 * Creates values for guiding movements.
@@ -239,7 +239,7 @@ class Telescope:public rts2core::Device
 		 * @param dec DEC correction
 		 */
 		virtual int applyCorrectionsFixed (double ra, double dec) { return -1; }
-	
+
 		/**
 		 * Returns telescope target RA.
 		 */
@@ -259,7 +259,7 @@ class Telescope:public rts2core::Device
 			equ->dec = getTelTargetDec ();
 			normalizeRaDec (equ->ra, equ->dec);
 		}
-		  
+
 		/**
 		 * Set telescope RA.
 		 *
@@ -277,7 +277,7 @@ class Telescope:public rts2core::Device
 		/**
 		 * Set telescope RA and DEC.
 		 */
-		void setTelRaDec (double new_ra, double new_dec) 
+		void setTelRaDec (double new_ra, double new_dec)
 		{
 			setTelRa (new_ra);
 			setTelDec (new_dec);
@@ -311,7 +311,7 @@ class Telescope:public rts2core::Device
 		/**
 		 * Set telescope untouched (i.e. physical) RA and DEC.
 		 */
-		void setTelUnRaDec (double new_ra, double new_dec) 
+		void setTelUnRaDec (double new_ra, double new_dec)
 		{
 			telUnRaDec->setRa (new_ra);
 			telUnRaDec->setDec (new_dec);
@@ -354,7 +354,7 @@ class Telescope:public rts2core::Device
 		 * every time mount homing commands is issued.
 		 *
 		 * ParkNum is used in the modelling to find observations
-		 * taken in interval with same park numbers, e.g. with sensors 
+		 * taken in interval with same park numbers, e.g. with sensors
 		 * homed at same location.
 		 */
 		void setParkTimeNow () { mountParkTime->setNow (); }
@@ -367,7 +367,7 @@ class Telescope:public rts2core::Device
 
 		/**
 		 * Apply model for RA/DEC position pos, for specified flip and JD.
-		 * All resulting coordinates also includes corrRaDec corection. 
+		 * All resulting coordinates also includes corrRaDec corection.
 		 * If writeValue is set to true, changes tel_target (telTargetRA) variable, including model computation and corrRaDec.
 		 * Also sets MO_RTS2 (modelRaDec) variable, mirroring (only) computed model difference.
 		 * Can be used to compute non-cyclic model, with flip=0 and pos in raw mount coordinates.
@@ -499,7 +499,7 @@ class Telescope:public rts2core::Device
 			_ori->ra = oriRaDec->getRa ();
 			_ori->dec = oriRaDec->getDec ();
 		}
-	
+
 		void setOrigin (double ra, double dec)
 		{
 			oriRaDec->setValueRaDec (ra, dec);
@@ -595,7 +595,7 @@ class Telescope:public rts2core::Device
 		 *
 		 * If tracking is set to object, future position is calculated from
 		 * current RA DEC position. Otherwise, future position is calculated
-		 * from target position, where target position can change in time (for 
+		 * from target position, where target position can change in time (for
 		 * MPEC and LTE targets).
 		 *
 		 * @param JD	         Julian date for which position will be calculated
@@ -729,7 +729,7 @@ class Telescope:public rts2core::Device
 		 * Return distance in degrees to target position.
 		 * You are responsible to call info() before this call to
 		 * update telescope coordinates.
-		 * 
+		 *
 		 * @return Sky distance in degrees to target, 0 - 180. -1 on error.
 		 */
 		double getTargetDistance ();
@@ -834,7 +834,7 @@ class Telescope:public rts2core::Device
 		/**
 		 * Stop telescope movement. It is called in two cases. Either when new
 		 * target is entered and telescope should stop movement to current target,
-		 * or when some failure of telescope is detected and telescope should stop 
+		 * or when some failure of telescope is detected and telescope should stop
 		 * current movement in order to prevent futher damage to the hardware.
 		 *
 		 * @return 0 on success, -1 on failure
@@ -847,7 +847,7 @@ class Telescope:public rts2core::Device
 		 */
 		virtual void telescopeAboveHorizon () {}
 
-		/** 
+		/**
 		 * Called when telescope is suddently pointed below horizon. Returns < 0 on error, 0 on sucess, 1 when abort was not called (temproary allowed violation of bellow horizon..)
 		 */
 		virtual int abortMoveTracking ();
@@ -1004,7 +1004,7 @@ class Telescope:public rts2core::Device
 		 * Telescope parking position.
 		 */
 		rts2core::ValueAltAz *parkPos;
-		
+
 		/**
 		 * Desired flip when parking.
 		 */
@@ -1118,7 +1118,7 @@ class Telescope:public rts2core::Device
 		/**
 		 * Limit for corrections.
 		 */
-		rts2core::ValueDouble *correctionLimit; 
+		rts2core::ValueDouble *correctionLimit;
 
 		/**
 		 * If move is above this limit, correction is rejected.
@@ -1332,10 +1332,12 @@ class Telescope:public rts2core::Device
 
 		rts2core::ValueInteger *moveNum;
 		rts2core::ValueInteger *corrImgId;
+		rts2core::ValueInteger *corrObsId;
 		rts2core::ValueInteger *failedMoveNum;
 		rts2core::ValueTime *lastFailedMove;
 
 		rts2core::ValueInteger *wCorrImgId;
+		rts2core::ValueInteger *wCorrObsId;
 
 		/**
 		 * Tracking / idle refresh interval

--- a/lib/rts2/command.cpp
+++ b/lib/rts2/command.cpp
@@ -443,11 +443,11 @@ int CommandChange::commandReturnFailed (int status, Connection * conn)
 	return Command::commandReturnFailed (status, conn);
 }
 
-CommandCorrect::CommandCorrect (Block * _master, int corr_mark, int corr_img, int img_id, double ra_corr, double dec_corr, double pos_err):Command (_master)
+CommandCorrect::CommandCorrect (Block * _master, int corr_mark, int corr_img, int corr_obs, int img_id, int obs_id, double ra_corr, double dec_corr, double pos_err):Command (_master)
 {
  	std::ostringstream _os;
-	_os << "correct " << corr_mark << " " << corr_img
-		<< " " << img_id << " " << std::fixed << ra_corr
+	_os << "correct " << corr_mark << " " << corr_img << " " << corr_obs
+		<< " " << img_id << " " << obs_id << " " << std::fixed << ra_corr
 		<< " " << dec_corr << " " << pos_err;
 	setCommand (_os);
 }

--- a/lib/rts2script/connimgprocess.cpp
+++ b/lib/rts2script/connimgprocess.cpp
@@ -165,7 +165,7 @@ int ConnImgProcess::newProcess ()
 void ConnImgProcess::connectionError (int last_data_size)
 {
 	const char *telescopeName;
-	int corr_mark, corr_img;
+	int corr_mark, corr_img, corr_obs;
 
 	if (last_data_size < 0 && errno == EAGAIN)
 	{
@@ -228,6 +228,7 @@ void ConnImgProcess::connectionError (int last_data_size)
 					{
 						image->getValue ("MOVE_NUM", corr_mark);
 						image->getValue ("CORR_IMG", corr_img);
+						image->getValue ("CORR_OBS", corr_obs);
 						if (telescopeName)
 						{
 							rts2core::Connection *telConn;
@@ -247,7 +248,7 @@ void ConnImgProcess::connectionError (int last_data_size)
 
 								double posErr = ln_get_angular_separation (&pos1, &pos2);
 
-								telConn->queCommand (new rts2core::CommandCorrect (master, corr_mark, corr_img, image->getImgId (), ra_err, dec_err, posErr));
+								telConn->queCommand (new rts2core::CommandCorrect (master, corr_mark, corr_img, corr_obs, image->getImgId (), image->getObsId (), ra_err, dec_err, posErr));
 							}
 						}
 					}

--- a/lib/rts2tel/teld.cpp
+++ b/lib/rts2tel/teld.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Telescope control daemon.
  * Copyright (C) 2003-2017 Petr Kubanek <petr@kubanek.net>
  *
@@ -76,7 +76,7 @@ Telescope::Telescope (int in_argc, char **in_argv, bool diffTrack, bool hasTrack
 	unstableDist = 0;
 
 	useParkFlipping = false;
-	
+
 	decUpperLimit = NULL;
 	dut1fn = NULL;
 
@@ -227,6 +227,7 @@ Telescope::Telescope (int in_argc, char **in_argv, bool diffTrack, bool hasTrack
 	createValue (total_offsets, "total_offsets", "[deg] OFFS - corr", false, RTS2_DT_DEG_DIST_180);
 
 	createValue (wCorrImgId, "wcorr_img", "Image id waiting for correction", false, RTS2_VALUE_WRITABLE, 0);
+	createValue (wCorrObsId, "wcorr_obs", "Observation id waiting for correction", false, RTS2_VALUE_WRITABLE, 0);
 
 	// position error
 	createValue (posErr, "pos_err", "error in degrees", false, RTS2_DT_DEG_DIST_180);
@@ -333,6 +334,8 @@ Telescope::Telescope (int in_argc, char **in_argv, bool diffTrack, bool hasTrack
 
 	createValue (corrImgId, "CORR_IMG", "ID of last image used for correction", true, RTS2_VALUE_WRITABLE);
 	corrImgId->setValueInteger (0);
+	createValue (corrObsId, "CORR_OBS", "ID of last observation used for correction", true, RTS2_VALUE_WRITABLE);
+	corrObsId->setValueInteger (0);
 
 	createValue (failedMoveNum, "move_failed", "number of failed movements", false);
 	failedMoveNum->setValueInteger (0);
@@ -836,7 +839,7 @@ double Telescope::getTargetDistance ()
 	if (modelTarAltAz != NULL)
 	{
 		struct ln_hrz_posn hrz_tar, hrz_tel;
-		modelTarAltAz->getAltAz (&hrz_tar);	
+		modelTarAltAz->getAltAz (&hrz_tar);
 		getTelAltAz (&hrz_tel);
 
 		tar.ra = hrz_tar.az;
@@ -1172,7 +1175,9 @@ void Telescope::incMoveNum ()
 	ignoreCorrection->setValueDouble (defIgnoreCorrection->getValueDouble ());
 
 	corrImgId->setValueInteger (0);
+	corrObsId->setValueInteger (0);
 	wCorrImgId->setValueInteger (0);
+	wCorrObsId->setValueInteger (0);
 
 	trackingNum = 0;
 	changeIdleMovingTracking ();
@@ -1238,7 +1243,7 @@ int Telescope::applyCorrRaDec (struct ln_equ_posn *pos, bool invertRa, bool inve
 	if (ln_get_angular_separation (&pos2, pos) > correctionLimit->getValueDouble ())
 	{
 		logStream (MESSAGE_WARNING) << "correction " << LibnovaDegDist (corrRaDec->getRa ()) << " " << LibnovaDegDist (corrRaDec->getDec ()) << " is above limit, ignoring it" << sendLog;
-		return -1; 
+		return -1;
 	}
 	pos->ra = pos2.ra;
 	pos->dec = pos2.dec;
@@ -1775,7 +1780,7 @@ void Telescope::logTracking ()
 		<< aberated->getRa () << " " << aberated->getDec () << " "
 		// 9
 		<< refraction->getValueDouble () << " "
-		// 10                             11 
+		// 10                             11
 		<< modelRaDec->getRa () << " " << modelRaDec->getDec () << " ";
 #endif
 	if (tarTelRaDec != NULL)
@@ -2039,13 +2044,12 @@ int Telescope::infoUTCLST (const double utc1, const double utc2, double telLST)
 			telescopeAboveHorizon ();
 		}
 	}
-	
+
 	return rts2core::Device::info ();
 }
 
 int Telescope::scriptEnds ()
 {
-	corrImgId->setValueInteger (0);
 	woffsRaDec->setValueRaDec (0, 0);
 	if (tracking)
 		tracking->setValueInteger (1);
@@ -2090,7 +2094,7 @@ void Telescope::applyCorrections (struct ln_equ_posn *pos, double utc1, double u
 	// apply all posible corrections
 	if (calPrecession->getValueBool () == true)
 		applyPrecession (pos, utc1 + utc2, writeValues);
-	
+
 	// always apply proper motion - if set
 	struct ln_equ_posn pm;
 	pm.ra = pmRaDec->getRa ();
@@ -2103,7 +2107,7 @@ void Telescope::applyCorrections (struct ln_equ_posn *pos, double utc1, double u
 		applyAberation (pos, utc1 + utc2, writeValues);
 	if (calRefraction->getValueBool () == true)
 		applyRefraction (pos, utc1 + utc2, writeValues);
-	
+
 	if (hrz != NULL)
 	{
 		getHrzFromEqu (pos, utc1 + utc2, hrz);
@@ -2214,7 +2218,7 @@ int Telescope::startResyncMove (rts2core::Connection * conn, int correction)
 		return -1;
 	}
 
-	// MPEC objects changes coordinates regularly, so we will not bother incrementing 
+	// MPEC objects changes coordinates regularly, so we will not bother incrementing
 	if (mpec->getValueString ().length () > 0)
 	{
 		if (mpec->wasChanged ())
@@ -2237,6 +2241,7 @@ int Telescope::startResyncMove (rts2core::Connection * conn, int correction)
 	{
 		corrRaDec->incValueRaDec (wcorrRaDec->getRa (), wcorrRaDec->getDec ());
 		corrImgId->setValueInteger (wCorrImgId->getValueInteger ());
+		corrObsId->setValueInteger (wCorrObsId->getValueInteger ());
 	}
 
 	if (woffsRaDec->wasChanged ())
@@ -2273,10 +2278,10 @@ int Telescope::startResyncMove (rts2core::Connection * conn, int correction)
 	LibnovaRaDec syncTo (&pos);
 	LibnovaRaDec syncFrom (telRaDec->getRa (), telRaDec->getDec ());
 
-	// now we have target position, which can be feeded to telescope
-	tarRaDec->setValueRaDec (pos.ra, pos.dec);
 	// calculate target after corrections from astrometry
 	applyCorrRaDec (&pos, false, false);
+	// now we have target position, which can be feeded to telescope
+	tarRaDec->setValueRaDec (pos.ra, pos.dec);
 
 	modelRaDec->setValueRaDec (0, 0);
 
@@ -2360,7 +2365,7 @@ int Telescope::startResyncMove (rts2core::Connection * conn, int correction)
 		LibnovaDegDist c_dec (corrRaDec->getDec ());
 
 		const char *cortype = "offseting and correcting";
-	
+
 		switch (correction)
 		{
 			case 1:
@@ -2743,21 +2748,33 @@ int Telescope::commandAuthorized (rts2core::Connection * conn)
 	{
 		int cor_mark;
 		int corr_img;
+		int corr_obs;
 		int img_id;
+		int obs_id;
 		double total_cor_ra;
 		double total_cor_dec;
 		double pos_err;
 		if (conn->paramNextInteger (&cor_mark)
 			|| conn->paramNextInteger (&corr_img)
+			|| conn->paramNextInteger (&corr_obs)
 			|| conn->paramNextInteger (&img_id)
+			|| conn->paramNextInteger (&obs_id)
 			|| conn->paramNextDouble (&total_cor_ra)
 			|| conn->paramNextDouble (&total_cor_dec)
 			|| conn->paramNextDouble (&pos_err)
 			|| !conn->paramEnd ())
 			return DEVDEM_E_PARAMSNUM;
+
+		logStream (MESSAGE_DEBUG) << "correct " << cor_mark << "=" << moveNum->getValueInteger () << "   "
+								 << corr_img << ":" << corr_obs  << "=" << corrImgId->getValueInteger () << ":" << corrObsId->getValueInteger () << "   "
+								 << img_id << ":" << obs_id << ">" << wCorrImgId->getValueInteger () << ":" << wCorrObsId->getValueInteger () << "   "
+								 << "cor_ra " << total_cor_ra << " cor_dec " << total_cor_dec << " err " << pos_err << sendLog;
+
 		if (applyCorrectionsFixed (total_cor_ra, total_cor_dec) == 0)
 			return DEVDEM_OK;
-		if (cor_mark == moveNum->getValueInteger () && corr_img == corrImgId->getValueInteger () && img_id > wCorrImgId->getValueInteger ())
+		if (cor_mark == moveNum->getValueInteger () &&
+			corr_img == corrImgId->getValueInteger () && corr_obs == corrObsId->getValueInteger () &&
+			(obs_id > wCorrObsId->getValueInteger () || img_id > wCorrImgId->getValueInteger ()))
 		{
 			if (pos_err < ignoreCorrection->getValueDouble ())
 			{
@@ -2772,6 +2789,8 @@ int Telescope::commandAuthorized (rts2core::Connection * conn)
 
 			wCorrImgId->setValueInteger (img_id);
 			sendValueAll (wCorrImgId);
+			wCorrObsId->setValueInteger (obs_id);
+			sendValueAll (wCorrObsId);
 
 			if (pos_err < smallCorrection->getValueDouble ()) {
 
@@ -2788,7 +2807,7 @@ int Telescope::commandAuthorized (rts2core::Connection * conn)
 			return 0;
 		}
 		std::ostringstream _os;
-		_os << "ignoring correction - cor_mark " << cor_mark << " moveNum " << moveNum->getValueInteger () << " corr_img " << corr_img << " corrImgId " << corrImgId->getValueInteger () << " img_id " << img_id << " wCorrImgId " << wCorrImgId->getValueInteger ();
+		_os << "ignoring correction - cor_mark " << cor_mark << " moveNum " << moveNum->getValueInteger () << " corr_img " << corr_img << ":" << corr_obs << " corrImgId " << corrImgId->getValueInteger () << ":" << corrObsId->getValueInteger () << " img_id " << img_id << ":" << obs_id << " wCorrImgId " << wCorrImgId->getValueInteger () << ":" << wCorrObsId->getValueInteger ();
 		conn->sendCommandEnd (DEVDEM_E_IGNORE, _os.str ().c_str ());
 		return -1;
 	}

--- a/scripts/rts2-astrometry.net
+++ b/scripts/rts2-astrometry.net
@@ -145,7 +145,8 @@ def run_on_image(fn, verbose=False, blind=False, noblind=False, multiwcs='', wcs
 		if raorig is not None and decorig is not None:
 			err = rts2.libnova.angular_separation(raorig, decorig, rastrxy[0] + x_o/3600.0, rastrxy[1] + y_o/3600.0)
 
-			ra_err = math.cos(math.radians(decorig))*((raorig-rastrxy[0])-x_o/3600.0)
+			# The code expects verbatim coordinate differences
+			ra_err = (raorig-rastrxy[0])-x_o/3600.0
 			dec_err = decorig-rastrxy[1]-y_o/3600.0
 
 			print "corrwerr 1 {0:.10f} {1:.10f} {2:.10f} {3:.10f} {4:.10f}".format(rastrxy[0], rastrxy[1], ra_err, dec_err, err)

--- a/src/teld/dummy.cpp
+++ b/src/teld/dummy.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Dummy telescope for tests.
  * Copyright (C) 2003-2008 Petr Kubanek <petr@kubanek.net>
  * Copyright (C) 2011 Petr Kubanek, Institute of Physics <kubanek@fzu.cz>
@@ -105,7 +105,7 @@ class Dummy:public Telescope
 
 		virtual void runTracking ();
 
-		virtual int sky2counts (const double utc1, const double utc2, struct ln_equ_posn *pos, int32_t &ac, int32_t &dc, bool writeValues);
+		virtual int sky2counts (const double utc1, const double utc2, struct ln_equ_posn *pos, struct ln_hrz_posn *hrz_out, int32_t &ac, int32_t &dc, bool writeValues, double haMargin, bool forceShortest);
 
 	private:
 
@@ -262,7 +262,7 @@ void Dummy::runTracking ()
 	Telescope::runTracking ();
 }
 
-int Dummy::sky2counts (const double utc1, const double utc2, struct ln_equ_posn *pos, int32_t &ac, int32_t &dc, bool writeValues)
+int Dummy::sky2counts (const double utc1, const double utc2, struct ln_equ_posn *pos, struct ln_hrz_posn *hrz_out, int32_t &ac, int32_t &dc, bool writeValues, double haMargin, bool forceShortest)
 {
 	ac = pos->ra * 10000;
 	dc = pos->dec * 10000;


### PR DESCRIPTION
- Proper order of operation: first apply the correction, then send it to telescope
- As the corrections are reset only on telescope repointing (increasing MOVE_NUM), we should properly handle the case of several observations (OBS_ID, with each observation resetting image ID) at the same position when checking of whether we should apply the correction
- Moreover, we should not reset correction counter on script end, as e.g. in looping observation the script will be run many times consecutively within the same observation. This sometimes led to correction being applied twice due to asynchronous nature of the process.
- Also, the code expects astrometry script to return verbatim coordinate differences, so we should not apply latitude correction to them there.
- also, minor fix for dummy driver

The code as it was never actually applied the correction in startResyncMove(), however, it seems it somehow worked on several telescopes still (like D50, according to Mates). Probably, it is applied somewhere else too (but it should really be applied only here, yes?). If it is so, please comment where I should also look for it.