### PR TITLE
Cleanup of autorestart, daemonization and lock file checking logic.

### DIFF
--- a/include/daemon.h
+++ b/include/daemon.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Daemon class.
  * Copyright (C) 2005-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -73,14 +73,14 @@ class Daemon:public Block
 		void initDaemon ();
 
 		/**
-		 * Set timer to send updates every interval seconds. This method is designed to keep user 
+		 * Set timer to send updates every interval seconds. This method is designed to keep user
 		 * infromed about progress of actions which rapidly changes values read by info call.
 		 *
-		 * @param interval If > 0, set idle info interval to this value. Daemon will then call info method every interval 
+		 * @param interval If > 0, set idle info interval to this value. Daemon will then call info method every interval
 		 *   seconds and distribute updates to all connected clients. If <= 0, disables automatic info.
 		 *
 		 * @see info()
-		 */  
+		 */
 		void setIdleInfoInterval (double interval);
 
 		/**
@@ -219,7 +219,7 @@ class Daemon:public Block
 		 * Delete all saved reference of given value.
 		 *
 		 * Used to clear saved values when the default value shall be changed.
-		 * 
+		 *
 		 * @param val Value which references will be deleted.
 		 */
 		void deleteSaveValue (CondValue * val);
@@ -235,7 +235,14 @@ class Daemon:public Block
 		/**
 		 * Sets lock filename.
 		 */
+		void setLockFile (std::string _lock_fname) { lock_fname = _lock_fname; }
 		void setLockFile (const char *_lock_fname) { lock_fname = std::string (_lock_fname); }
+
+		/**
+		 * Initializes the lock filename
+		 * To be reimplemented in derived classes that need custom lock file names
+		 */
+		virtual void initLockFile () { };
 
 		/**
 		 * Checks lockfile existence.
@@ -244,7 +251,6 @@ class Daemon:public Block
 		 * file should not be created, and -1 on error.
 		 */
 		int checkLockFile ();
-
 
 		void setNotDaemonize ()
 		{
@@ -299,7 +305,7 @@ class Daemon:public Block
 		{
 			lockPrefix = _lockPrefix;
 		}
-	
+
 		/**
 		 * Return prefix (directory) for lock files.
 		 *
@@ -379,7 +385,7 @@ class Daemon:public Block
 
 		/**
 		 * Set value. This is the function that get called when user want to change some value, either interactively through
-		 * rts2-mon, XML-RPC or from the script. You can overwrite this function in descendants to allow additional variables 
+		 * rts2-mon, XML-RPC or from the script. You can overwrite this function in descendants to allow additional variables
 		 * beiing overwritten. If variable has flag RTS2_VALUE_WRITABLE, default implemetation returns sucess. If setting variable
 		 * involves some special commands being send to the device, you most probably want to overwrite setValue, and provides
 		 * set action for your values in it.
@@ -519,7 +525,7 @@ class Daemon:public Block
 		{
 			if (std::isnan (info_time->getValueDouble ()))
 				return 86400;
-			return getNow () - info_time->getValueDouble ();	
+			return getNow () - info_time->getValueDouble ();
 		}
 
 
@@ -648,7 +654,7 @@ class Daemon:public Block
 		rts2core::ValueSelection *modesel;
 
 		/**
-		 * Add group to group list. Group values are values prefixed with 
+		 * Add group to group list. Group values are values prefixed with
 		 * group name, followed by '.'.
 		 *
 		 * For example if group list specify groups with names A and B, A.aa and

--- a/include/device.h
+++ b/include/device.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Device basic class.
  * Copyright (C) 2003-2010 Petr Kubanek <petr@kubanek.net>
  *
@@ -323,7 +323,7 @@ class Device:public Daemon
 
 		/**
 		 * Init hardware. This method shall close any opened connection
-		 * to hardware, and try to (re)-initialize hardware. 
+		 * to hardware, and try to (re)-initialize hardware.
 		 *
 		 * TODO should become pure virtual
 		 */
@@ -384,6 +384,8 @@ class Device:public Daemon
 		virtual int setValue (rts2core::Value * old_value, rts2core::Value * new_value);
 
 		void setDeviceName (const char *n) { device_name = n; }
+
+		virtual void initLockFile () { setLockFile (std::string (getLockPrefix ()) + std::string (device_name)); }
 
 	private:
 		std::list <HostString> centraldHosts;

--- a/lib/rts2/device.cpp
+++ b/lib/rts2/device.cpp
@@ -742,12 +742,6 @@ int Device::init ()
 		addCentraldConnection (conn_master, true);
 	}
 
-	std::string s = std::string (getLockPrefix ()) + std::string (device_name);
-	setLockFile (s.c_str ());
-	ret = checkLockFile ();
-	if (ret < 0)
-		exit (ret);
-
 	return initHardware ();
 }
 
@@ -773,18 +767,6 @@ void Device::beforeRun ()
 		logStream (MESSAGE_ERROR) << "some values are not set. Please see above errors and fix them, or run driver with --nocheck option" << sendLog;
 		exit (1);
 	}
-	int ret = doDaemonize ();
-	if (ret)
-		exit (ret);
-#ifndef RTS2_HAVE_FLOCK
-	// reopen..
-	ret = checkLockFile (lock_fname);
-	if (ret < 0)
-		exit (ret);
-#endif
-	ret = lockFile ();
-	if (ret)
-		exit (ret);
 }
 
 int Device::authorize (int centrald_num, DevConnection * conn)

--- a/lib/rts2/logstream.cpp
+++ b/lib/rts2/logstream.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Log steam, used for logging output.
  * Copyright (C) 2006-2009 Petr Kubanek <petr@kubanek.net>
  *

--- a/src/camd/andor.cpp
+++ b/src/camd/andor.cpp
@@ -82,10 +82,10 @@ using namespace std;
 // #define TEMP_SAFETY // turns out not to be supported ... :(
 
 
-// There is a bug in Andor Linux SDK 2.102.30045, one of the readout modes on 
-// iXon Ultra 888 is wrongly reported as not-available (by function 
-// IsPreAmpGainAvailable() ). 
-// This is dirty fix to avoid this misbehaviour and include this mode in 
+// There is a bug in Andor Linux SDK 2.102.30045, one of the readout modes on
+// iXon Ultra 888 is wrongly reported as not-available (by function
+// IsPreAmpGainAvailable() ).
+// This is dirty fix to avoid this misbehaviour and include this mode in
 // selection.
 //#define SDK_2_102_U888_FIX
 
@@ -567,7 +567,7 @@ int Andor::scriptEnds ()
 	return Camera::scriptEnds ();
 }
 
-// *** recalculate CCD timing, this function should be called after any change of parameters involved 
+// *** recalculate CCD timing, this function should be called after any change of parameters involved
 int Andor::setTiming ()
 {
 	int ret = DRV_SUCCESS;
@@ -636,7 +636,7 @@ int Andor::setTiming ()
 	// This replaces exposure in computation of time that will be spent waiting for data.
 	Camera::readoutTime->setValueDouble (acct - expt);
 
-	// calculate time to perorm a given acquisition 
+	// calculate time to perorm a given acquisition
 	// I would like to see "all exp+all readouts", but right now it is everything - one reaout
 	switch (acqMode->getValueInteger ())
 	{
@@ -1545,10 +1545,6 @@ int Andor::initAndorADCModes ()
 int Andor::initHardware ()
 {
 	int ret;
-
-	ret = rts2core::Device::doDaemonize ();
-	if (ret)
-		exit (ret);
 
 	ret = Initialize (andorRoot);
 	checkRet ("initHardware()", "Initialize()");

--- a/src/camd/gxccd.cpp
+++ b/src/camd/gxccd.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * MI CCD driver, compiled with official GXCCD drivers.
  * Copyright (C) 2016 Petr Kubanek, Institute of Physics <kubanek@fzu.cz>
  *
@@ -175,10 +175,6 @@ int GXCCD::processOption (int opt)
 
 int GXCCD::initHardware ()
 {
-	int ret = rts2core::Device::doDaemonize ();
-	if (ret)
-		exit (ret);
-
 	camera = gxccd_initialize_usb (id->getValueInteger ());
 	if (camera == NULL)
 	{
@@ -267,7 +263,7 @@ int GXCCD::initValues ()
 	ret = gxccd_get_integer_parameter (camera, GIP_PIXEL_D, &ph);
 	if (ret)
 		return -1;
-	
+
 	initCameraChip (w, h, pw, ph);
 
 	return Camera::initValues ();
@@ -527,7 +523,7 @@ int GXCCD::commandAuthorized (rts2core::Connection * conn)
 	}
 	return Camera::commandAuthorized (conn);
 }
-	
+
 int main (int argc, char **argv)
 {
 	GXCCD device (argc, argv);

--- a/src/camd/gxccd.cpp
+++ b/src/camd/gxccd.cpp
@@ -200,7 +200,7 @@ int GXCCD::initHardware ()
 		while (true)
 		{
 			char moden[200];
-			ret = gxccd_enumerate_read_modes (camera, rdm, moden, sizeof (moden));
+			int ret = gxccd_enumerate_read_modes (camera, rdm, moden, sizeof (moden));
 			if (ret)
 				break;
 			mode->addSelVal (moden);

--- a/src/centrald/centrald.cpp
+++ b/src/centrald/centrald.cpp
@@ -58,7 +58,7 @@ int ConnCentrald::sendDeviceKey ()
 	dev_key = random ();
 	if (dev_key == 0)
 		dev_key = 1;
-	std::ostringstream _os;	
+	std::ostringstream _os;
 	// device number could change..device names don't
 	char *dev_name;
 	rts2core::Connection *dev;
@@ -577,16 +577,6 @@ int Centrald::init ()
 
 	centraldConnRunning (NULL);
 
-	std::ostringstream _os;
-	_os << getLockPrefix () << "centrald_" << getPort ();
-	setLockFile (_os.str ().c_str ());
-	ret = checkLockFile ();
-	if (ret)
-		return ret;
-	ret = doDaemonize ();
-	if (ret < 0)
-		return ret;
-
 #ifndef RTS2_HAVE_FLOCK
 	// reopen..
 	ret = checkLockFile ();
@@ -961,7 +951,7 @@ int Centrald::weatherUpdate (rts2core::Connection *conn)
 	char *w_update;
 	if (conn->paramNextString (&w_device) || conn->paramNextString (&w_update) || !conn->paramEnd ())
 		return -2;
-	
+
 	if (!strcmp (w_device, badWeatherDevice->getValue ()))
 	{
 		badWeatherReason->setValueCharArr (w_update);

--- a/src/centrald/centrald.h
+++ b/src/centrald/centrald.h
@@ -241,6 +241,8 @@ class Centrald:public Daemon
 
 		virtual void signaledHUP ();
 
+		virtual void initLockFile () { setLockFile (std::string (getLockPrefix ()) + "centrald_" + std::to_string (getPort ())); }
+
 	private:
 		// called to change state, check if last_night_on should be set
 		void maskCentralState (rts2_status_t state_mask, rts2_status_t new_state, const char *description = NULL, double start = NAN, double end = NAN, Connection *commandedConn = NULL);

--- a/src/centrald/centrald.h
+++ b/src/centrald/centrald.h
@@ -241,7 +241,11 @@ class Centrald:public Daemon
 
 		virtual void signaledHUP ();
 
-		virtual void initLockFile () { setLockFile (std::string (getLockPrefix ()) + "centrald_" + std::to_string (getPort ())); }
+		virtual void initLockFile () {
+			std::ostringstream _os;
+			_os << getLockPrefix () << "centrald_" << getPort ();
+			setLockFile (_os.str ());
+		}
 
 	private:
 		// called to change state, check if last_night_on should be set

--- a/src/dome/door_vermes.cpp
+++ b/src/dome/door_vermes.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * dome door driver for Obs. Vermes.
  * Copyright (C) 2010 Markus Wildi
  * Copyright (C) 2008 Petr Kubanek <petr@kubanek.net>
@@ -26,8 +26,8 @@
 
 #include <connection.h>
 #include <dome.h>
-#include <vermes.h> 
-#include <door_vermes.h> 
+#include <vermes.h>
+#include <door_vermes.h>
 #include <vermes/move_door.h>
 #include <vermes/ssd650v_comm.h>
 #include <vermes/oak_comm.h>
@@ -49,11 +49,11 @@ extern pthread_t  move_door_id;
 
 namespace rts2dome {
 /*
- * Class to control of Obs. Vermes cupola door. 
+ * Class to control of Obs. Vermes cupola door.
  *
  * @author Markus Wildi <markus.wildi@one-arcsec.org>
  */
-  class DoorVermes: public Dome 
+  class DoorVermes: public Dome
   {
   private:
     rts2core::ValueString  *doorStateMessage;
@@ -66,7 +66,7 @@ namespace rts2dome {
     rts2core::ValueBool *manual;
     rts2core::ValueDouble *ssd650v_setpoint ;
     time_t nextDeadCheck; // wildi ToDo: clarify what happens!
-    rts2core::ValueString *lastMotorStop ;  
+    rts2core::ValueString *lastMotorStop ;
     rts2core::ValueDouble  *ssd650v_read_setpoint ;
     rts2core::ValueDouble  *ssd650v_current ;
 
@@ -84,11 +84,11 @@ namespace rts2dome {
     virtual int info ();
 
     virtual int idle ();
-    
+
     virtual int startOpen ();
     virtual long isOpened ();
     virtual int endOpen ();
-    
+
     virtual int startClose ();
     virtual long isClosed ();
     virtual int endClose ();
@@ -161,17 +161,17 @@ DoorVermes::updateDoorStatusMessage ()
     doorStateMessage->setValueString( msg) ;
   }
 }
-void 
+void
 DoorVermes::valueChanged (rts2core::Value * changed_value)
 {
-  if( simulate_door->getValueBool()) { 
+  if( simulate_door->getValueBool()) {
     // do not set status here
   } else {
     last_oak_digin_thread_heart_beat= oak_digin_thread_heart_beat ;
     struct timespec sl ;
     struct timespec rsl ;
     sl.tv_sec= 0. ;
-    sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC; 
+    sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC;
     nanosleep( &sl, &rsl) ;
 
     if( oak_digin_thread_heart_beat != last_oak_digin_thread_heart_beat) {
@@ -187,7 +187,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
   if(changed_value == stop_door) {
     if( stop_door->getValueBool()) {
       logStream (MESSAGE_INFO) << "DoorVermes::valueChanged stopping door" << sendLog ;
-      // it is already stop_door->setValueBool(true) ; 
+      // it is already stop_door->setValueBool(true) ;
       open_door->setValueBool(false) ;
       close_door->setValueBool(false) ;
       close_door_undefined->setValueBool(false) ;
@@ -227,7 +227,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
 	  struct timespec sl ;
 	  struct timespec rsl ;
 	  sl.tv_sec= 0. ;
-	  sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
+	  sl.tv_nsec= REPEAT_RATE_NANO_SEC;
 
 	  for( j= 0 ; j < 6 ; j++) {
 	    ret= nanosleep( &sl, &rsl) ;
@@ -256,7 +256,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
     if( close_door->getValueBool()) {
 
       logStream (MESSAGE_INFO) << "DoorVermes::valueChanged closing door" << sendLog ;
-      stop_door->setValueBool(false) ; 
+      stop_door->setValueBool(false) ;
       open_door->setValueBool(false) ;
       // it is already close_door->setValueBool(true) ;
       close_door_undefined->setValueBool(false) ;
@@ -274,8 +274,8 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
 	  struct timespec sl ;
 	  struct timespec rsl ;
 	  sl.tv_sec= 0. ;
-	  sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
-	
+	  sl.tv_nsec= REPEAT_RATE_NANO_SEC;
+
 	  for( j= 0 ; j < 6 ; j++) {
 	    ret= nanosleep( &sl, &rsl) ;
 	    if((ret== EFAULT) || ( ret== EINTR)||( ret== EINVAL ))  {
@@ -303,7 +303,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
     if( close_door_undefined->getValueBool()) {
 
       logStream (MESSAGE_WARNING) << "DoorVermes::valueChanged door state undefined, closing door slowly" << sendLog ;
-      stop_door->setValueBool(false) ; 
+      stop_door->setValueBool(false) ;
       open_door->setValueBool(false) ;
       close_door->setValueBool(false) ;
       // it is already close_door_undefined->setValueBool(true) ;
@@ -326,7 +326,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
 	  struct timespec sl ;
 	  struct timespec rsl ;
 	  sl.tv_sec= 0. ;
-	  sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
+	  sl.tv_nsec= REPEAT_RATE_NANO_SEC;
 
 	  for( j= 0 ; j < 6 ; j++) {
 	    ret= nanosleep( &sl, &rsl) ;
@@ -358,7 +358,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
       if( doorState!= DS_STOPPED_CLOSED) {
 	simulate_door->setValueBool (false);
 	logStream (MESSAGE_ERROR) << "DoorVermes::valueChanged do not switch to simulation mode while doorState!= DS_STOPPED_CLOSED" << sendLog ;
-	return ; 
+	return ;
       }
       logStream (MESSAGE_DEBUG) << "DoorVermes::valueChanged simulate door movements, stopping thread, entering simulation mode" << sendLog ;
       // strictly spoken: the motor has been already stopped, repeated here to make it sure
@@ -367,9 +367,9 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
       struct timespec sl ;
       struct timespec rsl ;
       sl.tv_sec= 0. ;
-      sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
-	
-      while(( ret= motor_off()) != SSD650V_MS_STOPPED) { // 
+      sl.tv_nsec= REPEAT_RATE_NANO_SEC;
+
+      while(( ret= motor_off()) != SSD650V_MS_STOPPED) { //
 	fprintf( stderr, "DoorVermes::valueChanged: can not turn motor off\n") ;
 	ret= nanosleep( &sl, &rsl) ;
 	if((ret== EFAULT) || ( ret== EINTR)||( ret== EINVAL ))  {
@@ -403,7 +403,7 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
       struct timespec sl ;
       struct timespec rsl ;
       sl.tv_sec= 0. ;
-      sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC; 
+      sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC;
       nanosleep( &sl, &rsl) ;
 
       if( oak_digin_thread_heart_beat != last_oak_digin_thread_heart_beat) {
@@ -441,8 +441,8 @@ DoorVermes::valueChanged (rts2core::Value * changed_value)
       }
     } else {
 	logStream (MESSAGE_INFO) << "DoorVermes::valueChanged ignoring changed value for ssd650v_setpoint, beeing in automatic mode, switch to MANUAL mode first" << sendLog ;
-    } 
-    
+    }
+
     return ;
   }
   Dome::valueChanged (changed_value);
@@ -457,13 +457,6 @@ DoorVermes::init ()
     return ret;
   // start in automatic mode
   ignoreEndswitch= NOT_IGNORE_END_SWITCH;
-
-  // make sure it forks before creating threads                                                                                    
-  ret = doDaemonize ();
-  if (ret) {
-      logStream (MESSAGE_ERROR) << "Doorvermes::initValues could not daemonize"<< sendLog ;
-      return ret;
-  }
 
   if( simulate_door->getValueBool()){
     oak_thread_state= THREAD_STATE_RUNNING ;
@@ -496,21 +489,21 @@ DoorVermes::init ()
     return ret;
   nextDeadCheck = 0;
   setIdleInfoInterval (20);
-  return 0;  
+  return 0;
 }
 
 int
 DoorVermes::info ()
 {
 
-  if( simulate_door->getValueBool()) { 
+  if( simulate_door->getValueBool()) {
     oak_thread_state= THREAD_STATE_RUNNING ;
   } else {
     last_oak_digin_thread_heart_beat= oak_digin_thread_heart_beat ;
     struct timespec sl ;
     struct timespec rsl ;
     sl.tv_sec= 0. ;
-    sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC; 
+    sl.tv_nsec= WAITING_FOR_HEART_BEAT_NANO_SEC;
     nanosleep( &sl, &rsl) ;
 
     if( oak_digin_thread_heart_beat != last_oak_digin_thread_heart_beat) {
@@ -519,12 +512,12 @@ DoorVermes::info ()
     } else {
       oak_thread_state= THREAD_STATE_UNDEFINED ;
       logStream (MESSAGE_ERROR) << "DoorVermes::valueChanged no heart beat from Oak thread" << sendLog ;
-      // do not exit here 
+      // do not exit here
     }
   }
   //updateDoorStatus() ;
   updateDoorStatusMessage() ;
-  lastMotorStop-> setValueString ( lastMotorStop_str) ; 
+  lastMotorStop-> setValueString ( lastMotorStop_str) ;
   double readSetPoint= get_setpoint() ;
   double current_percentage = get_current_percentage() ;
   ssd650v_read_setpoint->setValueDouble( readSetPoint) ;
@@ -552,12 +545,12 @@ DoorVermes::startOpen ()
   if( block_rts2_centrald->getValueBool()) {
     logStream (MESSAGE_ERROR) << "DoorVermes::startOpen blocked door opening (see BLOCK_RTS2_CENTRALD)" << sendLog ;
     return -1;
-  }  
+  }
   stop_door->setValueBool(false) ;
   open_door->setValueBool(false) ;
   close_door->setValueBool(false) ;
   close_door_undefined->setValueBool(false) ;
-  
+
   if( doorState== DS_RUNNING_OPEN) {
     logStream (MESSAGE_WARNING) << "DoorVermes::startOpen doorState== DS_RUNNING_OPEN, ignoring startOpen"<< sendLog ;
     return 0;
@@ -580,7 +573,7 @@ DoorVermes::startOpen ()
 	  struct timespec sl ;
 	  struct timespec rsl ;
 	  sl.tv_sec= 0. ;
-	  sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
+	  sl.tv_nsec= REPEAT_RATE_NANO_SEC;
 
 	  for( j= 0 ; j < 6 ; j++) {
 	    ret= nanosleep( &sl, &rsl) ;
@@ -600,7 +593,7 @@ DoorVermes::startOpen ()
 	if( k== 3) {
 	  logStream (MESSAGE_INFO) << "DoorVermes::startOpen doorEvent= EVNT_DOOR_CMD_OPEN: returning failiure (-1)" << sendLog ;
 	  return -1 ;
-	} else {  
+	} else {
 	  open_door->setValueBool(true) ;
 	  //wdoorState=DS_RUNNING_OPEN ;
 	  //wupdateDoorStatus() ;
@@ -641,7 +634,7 @@ DoorVermes::isOpened ()
   if( block_rts2_centrald->getValueBool()) {
     logStream (MESSAGE_ERROR) << "DoorVermes::isOpened blocked door opening (see BLOCK_RTS2_CENTRALD)" << sendLog ;
     return -1;
-  }  
+  }
 
   stop_door->setValueBool(false) ;
   open_door->setValueBool(false) ;
@@ -660,7 +653,7 @@ DoorVermes::isOpened ()
     open_door->setValueBool(true) ;
     return USEC_SEC;
   }
-  doorState=DS_STOPPED_OPENED; 
+  doorState=DS_STOPPED_OPENED;
   //updateDoorStatus() ;
   logStream (MESSAGE_INFO) << "DoorVermes::isOpened returning -2: it is OPEN"<< sendLog ;
   return -2;
@@ -680,7 +673,7 @@ DoorVermes::endOpen ()
   open_door->setValueBool(false) ;
   close_door->setValueBool(false) ;
   close_door_undefined->setValueBool(false) ;
-  
+
   if( doorState== DS_STOPPED_CLOSED) {
     logStream (MESSAGE_ERROR) << "DoorVermes::endOpen door is not open doorState== DS_STOPPED_CLOSED" << sendLog ;
     return -1 ;
@@ -713,11 +706,11 @@ DoorVermes::startClose ()
 {
   logStream (MESSAGE_INFO) << "DoorVermes::startClose, doorState: "<< doorState<< sendLog ;
   updateDoorStatusMessage() ;
-  
+
   if( block_rts2_centrald->getValueBool()) {
     logStream (MESSAGE_ERROR) << "DoorVermes::startClosed blocked door closing (see BLOCK_RTS2_CENTRALD)" << sendLog ;
     return -1;
-  }  
+  }
 
   stop_door->setValueBool(false) ;
   open_door->setValueBool(false) ;
@@ -750,7 +743,7 @@ DoorVermes::startClose ()
 	  struct timespec sl ;
 	  struct timespec rsl ;
 	  sl.tv_sec= 0. ;
-	  sl.tv_nsec= REPEAT_RATE_NANO_SEC; 
+	  sl.tv_nsec= REPEAT_RATE_NANO_SEC;
 
 	  for( j= 0 ; j < 6 ; j++) {
 	    ret= nanosleep( &sl, &rsl) ;
@@ -770,7 +763,7 @@ DoorVermes::startClose ()
 
 	if( k== 3) {
 	  return -1 ;
-	} else {  
+	} else {
 	  close_door->setValueBool(true) ;
 	  return 0 ;
 	}
@@ -790,7 +783,7 @@ DoorVermes::startClose ()
     logStream (MESSAGE_INFO) << "DoorVermes::startClose closing door, doorState" << doorState<< sendLog ;
     if( oak_thread_state== THREAD_STATE_RUNNING) {
       if( simulate_door->getValueBool()){
-      
+
       } else {
 
 	if( doorState== DS_RUNNING_OPEN) {
@@ -821,7 +814,7 @@ DoorVermes::startClose ()
  */
 long
 DoorVermes::isClosed ()
-{   
+{
   updateDoorStatusMessage() ;
 
   //logStream (MESSAGE_DEBUG) << "DoorVermes::isClosed"<< sendLog ;
@@ -829,7 +822,7 @@ DoorVermes::isClosed ()
   if( block_rts2_centrald->getValueBool()) {
       //logStream (MESSAGE_DEBUG) << "DoorVermes::isClosed blocked door closing (see BLOCK_RTS2_CENTRALD), returning -2 (is closed)" << sendLog ;
     return -2;
-  }  
+  }
 
   //return -2 ;
   stop_door->setValueBool(false) ;
@@ -850,7 +843,7 @@ DoorVermes::isClosed ()
     }
     close_door->setValueBool(true) ;
     return USEC_SEC;
-  } 
+  }
   return -2 ;
 }
 
@@ -869,7 +862,7 @@ DoorVermes::endClose ()
   open_door->setValueBool(false) ;
   close_door->setValueBool(false) ;
   close_door_undefined->setValueBool(false) ;
-  
+
   if( doorState== DS_STOPPED_CLOSED) {
     if( simulate_door->getValueBool()){
       logStream (MESSAGE_DEBUG) << "DoorVermes::endClose simulated door is closed" << sendLog ;
@@ -877,7 +870,7 @@ DoorVermes::endClose ()
       logStream (MESSAGE_INFO) << "DoorVermes::endClose door is closed" << sendLog ;
     }
     return 0 ;
-    
+
   } else if ( doorState== DS_STOPPED_OPENED) {
     logStream (MESSAGE_ERROR) << "DoorVermes::endClose door is open doorState== DS_STOPPED_OPENED"<< sendLog ;
     return -1;
@@ -920,7 +913,7 @@ DoorVermes::DoorVermes (int argc, char **argv): Dome (argc, argv)
   createValue( lastMotorStop,        "LASTSTOP", "date and time, when motor was last stopped by Oak sensors", false) ;
   createValue (doorStateMessage,     "DOORSTATE", "door state as clear text", false);
   createValue (block_rts2_centrald,           "BLOCK_RTS2_CENTRALD", "true inhibits rts2-centrald initiated door movements", false, RTS2_VALUE_WRITABLE);
-  block_rts2_centrald->setValueBool (false); 
+  block_rts2_centrald->setValueBool (false);
   createValue (stop_door,            "STOP_DOOR",  "true stops door",  false, RTS2_VALUE_WRITABLE);
   stop_door->setValueBool  (false);
   createValue (open_door,            "OPEN_DOOR",  "true opens door",  false, RTS2_VALUE_WRITABLE);

--- a/src/dome/vermes.cpp
+++ b/src/dome/vermes.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Obs. Vermes cupola driver.
  * Copyright (C) 2010 Markus Wildi <markus.wildi@one-arcsec.org>
  * based on Petr Kubanek's dummy_cup.cpp
@@ -19,10 +19,10 @@
  */
 
 #include "cupola.h"
-#include "configuration.h" 
+#include "configuration.h"
 
-// Obs. Vermes specific 
-#include <vermes.h> 
+// Obs. Vermes specific
+#include <vermes.h>
 #include <slitazimuth.h>
 #include <vermes/move_to_target_az.h>
 #include <vermes/barcodereader.h>
@@ -32,14 +32,14 @@ extern int is_synced ; // ==SYNCED if target_az reached
 extern int motorState ;
 extern int barcodereader_state ;
 extern double barcodereader_az ;
-extern double barcodereader_dome_azimut_offset ; 
+extern double barcodereader_dome_azimut_offset ;
 extern double target_az ;
 extern double manual_target_az ;
 extern struct ln_lnlat_posn obs_location ;
 extern struct ln_equ_posn   tel_equ ;
 extern double curMaxSetPoint ;
 extern double curMinSetPoint ;
-extern int movementState ; 
+extern int movementState ;
 extern double current_percentage ;
 extern double readSetPoint ;
 
@@ -71,7 +71,7 @@ namespace rts2dome
     virtual int moveEnd () ;
     virtual long isMoving () ;
     virtual int moveStop () ;
-    // there is no dome door to open 
+    // there is no dome door to open
     virtual int startOpen (){return 0;}
     virtual long isOpened (){return -2;}
     virtual int endOpen (){return 0;}
@@ -79,7 +79,7 @@ namespace rts2dome
     virtual long isClosed (){return -2;}
     virtual int endClose (){return 0;}
     virtual int stop (){return 0;};
-    
+
   public:
     Vermes (int argc, char **argv) ;
     virtual int initValues () ;
@@ -90,8 +90,8 @@ namespace rts2dome
     // park copula
     virtual int standby ();
     virtual int off ();
-    // done in thread void *move_to_target_azimuth, bypassing rts2  
-    virtual bool needSlitChange () { return true;}; 
+    // done in thread void *move_to_target_azimuth, bypassing rts2
+    virtual bool needSlitChange () { return true;};
   };
 }
 int Vermes::moveEnd ()
@@ -105,7 +105,7 @@ int Vermes::moveEnd ()
 int Vermes::moveStop ()
 {
   logStream (MESSAGE_INFO) << "Vermes::moveStop stopping cupola: "<< sendLog ;
-  movementState= SYNCHRONIZATION_DISABLED ; 
+  movementState= SYNCHRONIZATION_DISABLED ;
 
   struct timespec rep_slv ;
   struct timespec rep_rsl ;
@@ -163,13 +163,13 @@ int Vermes::moveStart ()
     logStream (MESSAGE_DEBUG) << "Vermes::moveStart new RA " << tel_equ.ra  << " Dec " << tel_equ.dec << sendLog ;
   }
 
-  movementState= SYNCHRONIZATION_ENABLED ; 
+  movementState= SYNCHRONIZATION_ENABLED ;
   logStream (MESSAGE_DEBUG) << "Vermes::moveStart synchronization of the telescope enabled"<< sendLog ;
   return Cupola::moveStart ();
 }
 void Vermes::parkCupola ()
 {
-  movementState= SYNCHRONIZATION_DISABLED ; 
+  movementState= SYNCHRONIZATION_DISABLED ;
   logStream (MESSAGE_DEBUG) << "Vermes::parkCupola synchronization disabled"<< sendLog ;
 }
 int Vermes::standby ()
@@ -188,7 +188,7 @@ void Vermes::valueChanged (rts2core::Value * changed_value)
   int ret ;
   static int lastMovementState ;
   if (changed_value == ssd650v_setpoint) {
- 
+
     if( ssd650v_setpoint->getValueDouble() != 0.) {
       manual_target_az= UNDEFINED;
       lastMovementState= movementState ;
@@ -202,8 +202,8 @@ void Vermes::valueChanged (rts2core::Value * changed_value)
     } else {
       movementState= lastMovementState ;
       logStream (MESSAGE_DEBUG) << "Vermes::valueChanged restored synchronization mode" << sendLog ;
-    } 
-    
+    }
+
     float setpoint= (float) ssd650v_setpoint->getValueDouble() ;
     float getpoint ;
     if(std::isnan( getpoint= set_setpoint( setpoint)))  {
@@ -213,13 +213,13 @@ void Vermes::valueChanged (rts2core::Value * changed_value)
 	if(( ret=motor_off()) != SSD650V_MS_STOPPED ) {
 	  logStream (MESSAGE_WARNING) << "Vermes::valueChanged motor_off != SSD650V_MS_STOPPED" << sendLog ;
 	  ssd650v_state->setValueString("motor undefined") ;
-	} 
+	}
       } else {
 	if(( ret=motor_on()) != SSD650V_MS_RUNNING ) {
 	  ssd650v_state->setValueString("motor undefined") ;
 	  logStream (MESSAGE_ERROR) << "Vermes::valueChanged could not turn motor on :" << setpoint << sendLog ;
-	} 
-      } 
+	}
+      }
     }
     return ; // ask Petr what to do in general if something fails within ::valueChanged
   } else   if (changed_value == synchronizeTelescope) {
@@ -256,7 +256,7 @@ int Vermes::idle ()
 }
 int Vermes::info ()
 {
-  barcode_reader_state->setValueInteger( barcodereader_state) ; 
+  barcode_reader_state->setValueInteger( barcodereader_state) ;
   setCurrentAz(barcodereader_az);
   setTargetAz(target_az) ;
   target_azimut_cupola->setValueDouble( target_az) ;
@@ -299,12 +299,6 @@ int Vermes::initValues ()
     logStream (MESSAGE_ERROR) << "Vermes::initValues could not read configuration"<< sendLog ;
     return -1;
   }
-  // make sure it forks before creating threads
-  ret = doDaemonize ();
-  if (ret) {
-    logStream (MESSAGE_ERROR) << "Vermes::initValues could not daemonize"<< sendLog ;
-    return ret;
-  }
 
   struct ln_lnlat_posn   *obs_loc_tmp= Cupola::getObserver() ;
   obs_location.lat= obs_loc_tmp->lat;
@@ -325,7 +319,7 @@ int Vermes::initValues ()
   if(( ret=motor_off()) != SSD650V_MS_STOPPED ) {
     logStream (MESSAGE_WARNING) << "Vermes::initValues motor_off != SSD650V_MS_STOPPED" << sendLog ;
     ssd650v_state->setValueString("motor undefined") ;
-  } 
+  }
 
   // set initial tel_eq to HA=0
   double JD= ln_get_julian_from_sys ();
@@ -341,7 +335,7 @@ int Vermes::initValues ()
 
   return Cupola::initValues ();
 }
-Vermes::Vermes (int in_argc, char **in_argv):Cupola (in_argc, in_argv) 
+Vermes::Vermes (int in_argc, char **in_argv):Cupola (in_argc, in_argv)
 {
   // since this driver is Obs. Vermes specific no options are really required
   createValue (target_azimut_cupola, "TargetAZ",        "target AZ calculated within driver", false, RTS2_DT_DEGREES | RTS2_VALUE_WRITABLE);
@@ -361,7 +355,7 @@ Vermes::Vermes (int in_argc, char **in_argv):Cupola (in_argc, in_argv)
   curMinSetPoint= ssd650v_min_setpoint->getValueDouble();
   curMaxSetPoint= ssd650v_max_setpoint->getValueDouble();
 
-  barcode_reader_state->setValueInteger( -1) ; 
+  barcode_reader_state->setValueInteger( -1) ;
 }
 int main (int argc, char **argv)
 {

--- a/src/sensord/tps534.cpp
+++ b/src/sensord/tps534.cpp
@@ -1,5 +1,5 @@
-/* 
- * sensor daemon for cloudsensor AAG designed by António Alberto Peres Gomes 
+/*
+ * sensor daemon for cloudsensor AAG designed by António Alberto Peres Gomes
  * Copyright (C) 2009, Markus Wildi, Petr Kubanek <petr@kubanek.net>
  *
  * This program is free software; you can redistribute it and/or
@@ -82,7 +82,7 @@ TPS534::processOption (int in_opt)
 	}
 	return 0;
 }
-int 
+int
 TPS534::willConnect (rts2core::NetworkAddress * in_addr)
 {
     if (doorDevice && in_addr->getType () == DEVICE_TYPE_DOME) {
@@ -98,13 +98,6 @@ TPS534::init ()
 	ret = SensorWeather::init ();
 	if (ret)
 		return ret;
-	// make sure it forks before creating threads
-	ret = doDaemonize ();
-
-	if (ret) {
-	  logStream (MESSAGE_ERROR) << "Doorvermes::initValues could not daemonize"<< sendLog ;
-	  return ret;
-	}
 
 	addConstValue ("DOOR", doorDevice, "door device name to monitor its state (open/closed)");
 	connectDevice(device_file, 1);
@@ -112,7 +105,7 @@ TPS534::init ()
 	if (!std::isnan (triggerSky->getValueDouble ()))
 		setWeatherState (false, "cloud trigger unspecified");
 
-	
+
 	for( int i = 0; i < 6; i++) {
 	  tps534LastState.analogIn[i]= 0. ;
 	}
@@ -140,14 +133,14 @@ TPS534::info ()
         } else {
 	  doorOpen= false ;
       	}
-      }  
+      }
     } else {
       logStream (MESSAGE_DEBUG) << "TPS534::info doorState=NULL : "<< sendLog;
     }
-  }  
+  }
 
   if( doorOpen) {
-    // Check if thread died  
+    // Check if thread died
     if( last_read_oak_cnt >= read_oak_cnt) {
       logStream (MESSAGE_ERROR) << "TPS534::info oak thread died" << sendLog;
     } else {

--- a/src/thrift/thriftd.cpp
+++ b/src/thrift/thriftd.cpp
@@ -198,10 +198,6 @@ int ThriftD::init ()
 	if (ret)
 		return ret;
 
-	ret = rts2core::Device::doDaemonize ();
-	if (ret)
-		return ret;
-
 	pthread_create (&thrift_thr, NULL, &thrift_thread, NULL);
 	return 0;
 }
@@ -287,7 +283,7 @@ int ThriftD::idle ()
 			domeInfo.DomeAngle = ln_range_degrees (val->getValueDouble () + 180.0);
 		}
 	}
-	
+
 	return Device::idle ();
 }
 


### PR DESCRIPTION
Basically, we have to setup autorestart before any network connection is opened (or it will not operate properly after restart), i.e. as early as possible, right after command-line option parsing. But the daemonization have to be even earlier, and lock file checking have to be even before daemonization. So all of this is moved upward in the operation queue. And some device daemons that manually implemented early daemonization (as their low-level kernel drivers dislike forking etc) are cleaned up as they do not need to bother with it anymore.