### PR TITLE
Quoted strings support in 'exe' script command argument. Also, a small improvement for image simulator. 

### DIFF
--- a/lib/rts2script/script.cpp
+++ b/lib/rts2script/script.cpp
@@ -65,10 +65,21 @@ bool Script::isNext (const char *element)
 char *Script::nextElement ()
 {
 	char *elementStart;
+	char endChar = 0;
+
 	while (isspace (*cmdBufTop))
 		cmdBufTop++;
+
+	if (*cmdBufTop == '"' || *cmdBufTop == '\'')
+	{
+		// Quoted string started, we will select until matching end character;
+		endChar = *cmdBufTop;
+		cmdBufTop++;
+	}
+
 	elementStart = cmdBufTop;
-	while (!isspace (*cmdBufTop) && *cmdBufTop)
+	while (((endChar == 0 && !isspace (*cmdBufTop)) ||
+			(endChar && *cmdBufTop != endChar)) && *cmdBufTop)
 		cmdBufTop++;
 	if (*cmdBufTop)
 	{
@@ -238,14 +249,14 @@ int Script::setTarget (const char *cam_name, Rts2Target * target)
 	target->getPosition (&target_pos);
 
 	strcpy (defaultDevice, cam_name);
-	
+
 	// set device specific values
 	Configuration *config = Configuration::instance ();
 	config->getFloat (cam_name, "readout_time", fullReadoutTime, fullReadoutTime);
 	config->getFloat (cam_name, "filter_movement", filterMovement, filterMovement);
 	config->getFloat ("observatory", "telescope_settle_time", telescopeSettleTime, telescopeSettleTime);
 	config->getFloat ("observatory", "telescope_speed", telescopeSpeed, telescopeSpeed);
-	
+
 	commentNumber = 1;
 	wholeScript = std::string ("");
 
@@ -802,7 +813,7 @@ rts2operands::Operand * Script::parseOperand (Rts2Target *target, rts2operands::
 			{
 				cmp = rts2operands::CMP_GREAT;
 			}
-			else 
+			else
 			{
 				throw ParsingError ("In conditions, only == is allowed");
 			}
@@ -998,7 +1009,7 @@ double rts2script::getMaximalScriptDuration (Rts2Target *tar, rts2db::CamList &c
 		script.setTarget (cam->c_str (), tar);
 		double d = script.getExpectedDuration (tel, runnum);
 		if (d > md)
-			md = d;  
+			md = d;
 	}
 	return md;
 }

--- a/man/rts2.script.txt
+++ b/man/rts2.script.txt
@@ -27,12 +27,14 @@ cmd {command}[({arg{,arg2..}})]::
     can be specified in round bracket, separated with comma,
     without any space between command and ending bracket.
 
-exe {executable filename}::
+exe {executable}::
     Execute external script. The script communicates with executor
     through standard input and outputs - both normal and error
     output. For documentation of the protocol, as well as
     available Python class for handling of this communication,
-    please see bellow.
+    please see bellow. The executable may be either a filename or a
+    quoted string containing filename and command-line parameters to
+    be passed to it.
 
 SEQUENCE {filter} {repeat} {exposure_time}::
     Performs exposure sequence. First set a filter, described as
@@ -77,7 +79,7 @@ I {exposure_time}::
     offsets,..) must be coma "," separated and enclosed in round
     brackets "(", ")". This is valid syntax for increase of the
     telescope offset by 10 degrees in RA and 5 degrees in DEC:
-    
+
     * T0.OFFS+=(10,5)
 
 {device name}.!{value name}operation{new value}::
@@ -240,7 +242,7 @@ exposure::
     others current settings will be used.
 
     When exposure is finished, controlling script receives notification
-    on standard input with *exposure_end* string. 
+    on standard input with *exposure_end* string.
 
     When the image is written to disk, controlling script receives image name
     on standard input, preceeded by *image* string. Script is responsible to
@@ -279,7 +281,7 @@ rename {image name} {expression}::
 echo exposure
 read exposure_end # is notified of exposure end
 read image imagename  # $image will hold "image" string
-echo rename $imagename /foo/bar/%f  # renames acquired image to /foo/bar/{standard image pattern}	
+echo rename $imagename /foo/bar/%f  # renames acquired image to /foo/bar/{standard image pattern}
 read new_name # reads new image name to $new_name
 ```
 
@@ -357,7 +359,7 @@ value {value name} {operator} {operand1 [operand2..]}::
 
 ``` bash
 echo value exposure += 1
-echo value WINDOW = 0 0 10 10 
+echo value WINDOW = 0 0 10 10
 ```
 
 device_by_type {device_type}::
@@ -424,7 +426,7 @@ waitidle {device name} {timeout}::
 
     This function is equvivalent to calling *S* command, compare status and
     return 1 if device properly reached idle, 0 if it timeouts.
-
+w
 C {device name} {command..}::
     Executes an arbitary command on device. Please see device drivers source
     code for allowed commands - they are called from commandAuthorize call.
@@ -655,7 +657,7 @@ focpos-=50 for 10 { E 5 focpos+=10 }
     This script test how various SPL_MODE affect resulting image. Sequence of
     1, 5 and 10 seconds exposures is taken, then SPL_MODE variable is increased
     by 1.
- 
+
 ```
 for 3 { E 1 E 5 E 10 SPL_MODE+=1 }
 ```
@@ -721,4 +723,3 @@ AUTHOR
 ------
 
 Petr Kubanek <petr@rts2.org>
-


### PR DESCRIPTION
Now it is possible to pass it a command with command line parameters, which will be correctly passed to the executable. Parameters in turn may also contain quoted strings, if you use proper quote type (as both ' and " quotations are supported).

Also, a small improvement for image simulator. 
It all had to be part of larger autofocusing-related PR, but that part is not quite ready yet, so pushing just these two things for now, as they are usable by itself.