### PR TITLE
Use std::isnan in place of isnan so that older compilers in C++11 mode are happy

### DIFF
--- a/checks/check_dut1.cpp
+++ b/checks/check_dut1.cpp
@@ -26,14 +26,14 @@ START_TEST(GETDUT1)
 	gmt.tm_year = 118;
 	gmt.tm_mon = 1;
 	gmt.tm_mday = 5;
-	ck_assert_msg (isnan (getDUT1 ("data/finals2000A.daily", &gmt)), "data for 2018 found!");
+	ck_assert_msg (std::isnan (getDUT1 ("data/finals2000A.daily", &gmt)), "data for 2018 found!");
 
 	gmt.tm_year = 117;
 	gmt.tm_mon = 6;
 	gmt.tm_mday = 28;
 	ck_assert_dbl_eq (getDUT1 ("data/finals2000A.daily", &gmt), 1.3652135, 10e-5);
 
-	ck_assert_msg (isnan (getDUT1 ("data/final2000A.daily", &gmt)), "data for not existing file found!");
+	ck_assert_msg (std::isnan (getDUT1 ("data/final2000A.daily", &gmt)), "data for not existing file found!");
 }
 END_TEST
 
@@ -55,10 +55,10 @@ START_TEST(UPDATE)
 
 	double dut1 = getDUT1 (fn, gmt);
 	printf ("Current DUT1: %f\n", dut1);
-	ck_assert_msg (!isnan (dut1), "current data not found in downloade time diff file!");
+	ck_assert_msg (!std::isnan (dut1), "current data not found in downloade time diff file!");
 
 	gmt->tm_year += 3;
-	ck_assert_msg (isnan (getDUT1 (fn, gmt)), "found data for DUT1 3 years from now!");
+	ck_assert_msg (std::isnan (getDUT1 (fn, gmt)), "found data for DUT1 3 years from now!");
 
 	unlink (fn);
 }

--- a/lib/rts2/radecparser.cpp
+++ b/lib/rts2/radecparser.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Parser for RA DEC string.
  * Copyright (C) 2008 Petr Kubanek <petr@kubanek.net>
  *
@@ -18,11 +18,11 @@
  */
 
 #include <sstream>
+#include <cmath>
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
-#include <math.h>
 #include <string.h>
 
 #include "radecparser.h"
@@ -59,7 +59,7 @@ double parseDMS (const char *hptr, double *mul)
 		errno = 0;
 		// convert test
 		double n = strtod (locptr, &endptr);
-		if (isnan (n) || isinf (n))
+		if (std::isnan (n) || std::isinf (n))
 		{
 			errno = ERANGE;
 			return NAN;

--- a/lib/rts2/utilsfunc.cpp
+++ b/lib/rts2/utilsfunc.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Various utility functions.
  * Copyright (C) 2003-2008 Petr Kubanek <petr@kubanek.net>
  *
@@ -27,6 +27,7 @@
 #include <malloc.h>
 #endif
 #include <iostream>
+#include <cmath>
 #include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -234,10 +235,10 @@ std::vector<std::string> SplitStr(const std::string& text, const std::string& de
 	std::size_t delimlen = delimeter.length();
 
 	std::vector<std::string> result;
-	
+
 	if (text.empty ())
 		return result;
-	
+
 	while (pos != std::string::npos)
 	{
 		pos = text.find(delimeter, oldpos);
@@ -264,7 +265,7 @@ std::vector<char> Str2CharVector (std::string text)
 	std::vector<char> res;
 	for (std::string::iterator iter = text.begin(); iter != text.end(); iter++)
 	{
-		res.push_back (*iter);	
+		res.push_back (*iter);
 	}
 	return res;
 }
@@ -391,7 +392,7 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream)
 	char *ret = fgets (*lineptr, *n, stream);
 	if (ret == NULL)
 		return -1;
-	return *n; 
+	return *n;
 }
 #endif
 
@@ -417,7 +418,7 @@ const char * multiWCS (const char *name, char multi_wcs)
 
 int db_nan_indicator (double value)
 {
-	return isnan (value) ? -1 : 0;
+	return std::isnan (value) ? -1 : 0;
 }
 
 double db_nan_double (double value, int ind)

--- a/lib/rts2lx200/pier-collision.cpp
+++ b/lib/rts2lx200/pier-collision.cpp
@@ -22,6 +22,8 @@
 /* License along with this library; if not, write to the Free Software */
 /* Foundation, Inc., 51 Franklin Steet, Fifth Floor, Boston, MA  02110-1301  USA */
 
+#include <cmath>
+
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -81,23 +83,23 @@ int  pier_collision (struct ln_equ_posn *tel_equ, struct ln_lnlat_posn *obs)
 	pr.floor= -1.9534;
 	pr.danger_zone_below= -2.9534;
 	pr.danger_zone_above= -0.1;
-  
+
 	mt.xd = -0.0684;
 	mt.zd = -0.1934;
 	mt.rdec = 0.338;
 
 	tel.radius= 0.123;
-	tel.rear_length = 1.1; // 0.8 + 0.3 for FLI equipment 
+	tel.rear_length = 1.1; // 0.8 + 0.3 for FLI equipment
 
 	if ((tel_equ->dec > 90.) && ( tel_equ->dec <= 270.)) // EAST: DECaxis==HA - M_PI/2
 	{
 		tmp_equ.ra = tel_equ->ra - 180.;
-		tmp_equ.dec = -tel_equ->dec; 
+		tmp_equ.dec = -tel_equ->dec;
 	}
 	else // WEST: DECaxis==HA + M_PI/2
 	{
 		tmp_equ.ra =  tel_equ->ra;
-		tmp_equ.dec=  tel_equ->dec; 
+		tmp_equ.dec=  tel_equ->dec;
 	}
 	return LDCollision (tmp_equ.ra/180. * M_PI, tmp_equ.dec/180. * M_PI, obs->lng/180.*M_PI, obs->lat/180.*M_PI, mt.zd, mt.xd, mt.rdec, tel.radius, pr.radius);
 }
@@ -118,14 +120,14 @@ double LDRAtoHA (double RA, double longitude)
 	double HA;
 	double JD;
 	double theta_0 = 0.;
-    
+
 	JD = ln_get_julian_from_sys ();
 
-	theta_0 = 15. / 180. * M_PI * ln_get_mean_sidereal_time (JD); 
+	theta_0 = 15. / 180. * M_PI * ln_get_mean_sidereal_time (JD);
 	/* negative to the West, Kstars neg., XEpehem pos */
 	HA =  fmod(theta_0 + longitude - RA + 2. * M_PI,  2. * M_PI) ;
 	return HA ;
-} 
+}
 
 int LDCollision( double RA, double dec, double lambda, double phi, double zd, double xd, double Rdec, double Rtel, double Rpier)
 {
@@ -136,14 +138,14 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
   double tpm1= NAN;
   double czp1= NAN;
   double czm1= NAN;
-  
+
   double tpp3= NAN;
   double tpm3= NAN;
   double czp3= NAN;
   double czm3= NAN;
-    
+
   double HA ;
-  
+
   HA= LDRAtoHA( RA, lambda) ;
 
 /* Parameter of the straight line */
@@ -156,31 +158,31 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
 
 /* z componet of the intersection */
 
-  if( !isnan(tpp1)){
+  if( !std::isnan(tpp1)){
     czp1= LDTangentPlaneLineP(HA, dec, phi, zd, xd, Rdec, Rtel, tpp1) ;
   } else {
     //fprintf( stderr, "LDCollision tpp1==nan\n") ;
   }
-  if( !isnan(tpm1)){ 
+  if( !std::isnan(tpm1)){
     czm1= LDTangentPlaneLineM(HA, dec, phi, zd, xd, Rdec, Rtel, tpm1) ;
   } else {
     //fprintf( stderr, "LDCollision tpm1==nan\n") ;
   }
-  if( !isnan(tpp3)) {
+  if( !std::isnan(tpp3)) {
     czp3= LDTangentPlaneLineP(HA, dec, phi, zd, xd, Rdec, Rtel, tpp3) ;
   } else {
     //fprintf( stderr, "LDCollision tpp3==nan\n") ;
   }
-  if( !isnan(tpm3)) {
+  if( !std::isnan(tpm3)) {
     czm3= LDTangentPlaneLineM(HA, dec, phi, zd, xd, Rdec, Rtel, tpm3) ;
   }  else {
     //fprintf( stderr, "LDCollision tpm3==nan\n") ;
   }
 
-  if( !isnan(czp1)) {
+  if( !std::isnan(czp1)) {
     //if((czp1 > PierN[2].value) && ( czp1 < PierN[1].value))
     if((czp1 > pr.floor) && ( czp1 < pr.wedge)) {
-      if( !isnan(tpp1)){
+		if( !std::isnan(tpp1)){
 	if( fabs(tpp1) > tel.rear_length){
 	  fprintf( stderr, "LDCollision NO_COLLISION czp1, tpp1 %f> %f\n", fabs(tpp1), tel.rear_length) ;
 	  if( state_collision != COLLIDING) {
@@ -199,14 +201,14 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
     } else  if((czp1 < pr.danger_zone_above) && ( czp1 >= pr.wedge)){
       fprintf(stderr, "Within danger zone above 1 on the positive side\n") ;
       state_danger= WITHIN_DANGER_ZONE_ABOVE ;
-    } 
+    }
   } else {
     //fprintf( stderr, "LDCollision czp1==nan\n") ;
   }
-  if(  !isnan(czm1)){
+  if(  !std::isnan(czm1)){
     //if((czm1 > PierN[2].value) && ( czm1 < PierN[1].value))
     if((czm1 > pr.floor) && ( czm1 < pr.wedge)){
-      if( !isnan(tpm1)){
+		if( !std::isnan(tpm1)){
 	if( fabs(tpm1) > tel.rear_length){
 	  fprintf( stderr, "LDCollision NO_COLLISION czm1, tpm1 %f> %f\n", fabs(tpm1), tel.rear_length) ;
 	  if( state_collision != COLLIDING) {
@@ -229,10 +231,10 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
   } else {
     //fprintf( stderr, "LDCollision czm1==nan\n") ;
   }
-  if(  !isnan(czp3)) {
+  if(  !std::isnan(czp3)) {
     //if((czp3 > PierN[2].value) && ( czp3 < PierN[1].value))
     if((czp3 > pr.floor) && ( czp3 < pr.wedge)){
-      if( !isnan(tpp3)){
+		if( !std::isnan(tpp3)){
 	if( fabs(tpp3) > tel.rear_length){
 	  fprintf( stderr, "LDCollision NO_COLLISION czp3, tpp3 %f> %f\n", fabs(tpp3), tel.rear_length) ;
 	  if( state_collision != COLLIDING) {
@@ -255,10 +257,10 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
   } else {
     //fprintf( stderr, "LDCollision czp3==nan\n") ;
   }
-  if(  !isnan(czm3)) {
+  if(  !std::isnan(czm3)) {
     //if((czm3 > PierN[2].value) && ( czm3 < PierN[1].value))
     if((czm3 > pr.floor) && ( czm3 < pr.wedge)){
-      if( !isnan(tpm3)){
+		if( !std::isnan(tpm3)){
 	if( fabs(tpm3) > tel.rear_length){
 	  fprintf( stderr, "LDCollision NO_COLLISION czm3, tpm3 %f> %f\n", fabs(tpm3), tel.rear_length) ;
 	  if( state_collision != COLLIDING) {
@@ -285,24 +287,24 @@ int LDCollision( double RA, double dec, double lambda, double phi, double zd, do
     return COLLIDING ;
   } else if (state_danger != NO_DANGER) {
     return WITHIN_DANGER_ZONE ;
-  }  
+  }
   return NO_COLLISION ;
 }
 double LDTangentPlaneLineP(double HA, double dec, double phi, double zd, double xd, double Rdec, double Rtel, double tp)
 {
   double val= NAN;
-  val = zd - sqrt(pow(Rdec,2))*cos(phi)*sin(HA) + (Rdec*Rtel*cos(phi)*sin(HA))/sqrt(pow(Rdec,2)) + 
+  val = zd - sqrt(pow(Rdec,2))*cos(phi)*sin(HA) + (Rdec*Rtel*cos(phi)*sin(HA))/sqrt(pow(Rdec,2)) +
     (Rdec*Rtel*(cos(HA)*cos(phi)*sin(dec) - cos(dec)*sin(phi)))/sqrt(pow(Rdec,2)) + tp*(cos(HA)*cos(dec)*cos(phi) + sin(dec)*sin(phi)) ;
 
   //  fprintf( stderr, "====LDTangentPlaneLineP: WEST %+010.5f\n", val) ;
-  
+
   return val ;
 }
 
 double LDTangentPlaneLineM(double HA, double dec, double phi, double zd, double xd, double Rdec, double Rtel, double tp)
 {
   double val= NAN;
-  val=   zd - sqrt(pow(Rdec,2))*cos(phi)*sin(HA) + (Rdec*Rtel*cos(phi)*sin(HA))/sqrt(pow(Rdec,2)) + 
+  val=   zd - sqrt(pow(Rdec,2))*cos(phi)*sin(HA) + (Rdec*Rtel*cos(phi)*sin(HA))/sqrt(pow(Rdec,2)) +
 	   (Rdec*Rtel*(-(cos(HA)*cos(phi)*sin(dec)) + cos(dec)*sin(phi)))/sqrt(pow(Rdec,2)) + tp*(cos(HA)*cos(dec)*cos(phi) + sin(dec)*sin(phi));
 
   //  fprintf( stderr, "----LDTangentPlaneLineM: WEST %+010.5f\n\n", val ) ;
@@ -314,33 +316,33 @@ double LDCutPierLineP1(double HA, double dec, double phi, double zd, double xd, 
 {
   double val= NAN;
 
-  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) - 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) - 
-     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) - 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) + 
-     Rpier*cos(HA)*(-(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi)) + 
-        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) - 
-        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) - 
+  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) -
+     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) -
+     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) -
+     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) +
+     Rpier*cos(HA)*(-(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi)) +
+        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) -
+        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) -
      Csc(HA)*Sec(dec)*sqrt(pow(Rpier,2)*pow(cos(dec),2)*pow(sin(HA),2)*
-        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) + 
+        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) +
           pow(Rdec,2)*pow(cos(phi),2)*pow(sin(dec),2)*
-           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*Rdec*Rtel*cos(HA)*sin(HA)*sin(dec) + 
-             pow(Rtel,2)*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) + 
-          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) - 
-          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) - 
-             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) + 
-             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) + 
-             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) + 
-                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) + 
-             Rdec*((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec) + 
-                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) + 
-          cos(dec)*sin(dec)*(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec) - 
-             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) - 
-                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) + 
-             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) - 
-                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) + 2*Rdec*Rtel*sin(HA)*sin(phi))) + 
+           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*Rdec*Rtel*cos(HA)*sin(HA)*sin(dec) +
+             pow(Rtel,2)*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) +
+          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) -
+          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) -
+             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) +
+             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) +
+             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) +
+                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) +
+             Rdec*((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec) +
+                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) +
+          cos(dec)*sin(dec)*(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec) -
+             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) -
+                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) +
+             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) -
+                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) + 2*Rdec*Rtel*sin(HA)*sin(phi))) +
                 pow(Rdec,2)*sin(HA)*sin(dec)*sin(2*phi))))))/
-   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) + 
+   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) +
        pow(cos(dec),2)*(pow(sin(HA),2) + pow(cos(HA),2)*pow(sin(phi),2))));
 
   //  fprintf( stderr, "____LDCutPierLineP1: WEST %+010.5f\n", val) ;
@@ -349,34 +351,34 @@ double LDCutPierLineP1(double HA, double dec, double phi, double zd, double xd, 
 double LDCutPierLineM1(double HA, double dec, double phi, double zd, double xd, double Rdec, double Rtel, double Rpier)
 {
   double val= NAN;
-    
-  val= (Rdec*Rpier*xd*cos(phi)*sin(dec) - sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) + 
-	     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) - 
-	     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) + 
-	     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) + 
-	     Rpier*cos(HA)*(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi) - 
-			    sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) - 
-			    cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) - 
+
+  val= (Rdec*Rpier*xd*cos(phi)*sin(dec) - sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) +
+	     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) -
+	     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) +
+	     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) +
+	     Rpier*cos(HA)*(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi) -
+			    sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) -
+			    cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) -
 	     Csc(HA)*Sec(dec)*sqrt(pow(Rpier,2)*pow(cos(dec),2)*pow(sin(HA),2)*
-				   (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) + 
+				   (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) +
 				    pow(Rdec,2)*pow(cos(phi),2)*pow(sin(dec),2)*
-				    (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*pow(Rtel,2)*cos(HA)*sin(HA)*sin(dec) + 
-				     Rdec*Rtel*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) - 
-				    2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) - 
-				    Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) - 
-							  2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) + 
-							  Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) + 
-							  Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) + 
-									       2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) + 
-							  Rdec*(-((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec)) + 
-								pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) + 
-				    cos(dec)*sin(dec)*(-(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec)) - 
-						       2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) - 
-									   pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) + 
-						       Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) + 
-									    sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) - 2*pow(Rdec,2)*sin(HA)*sin(phi))) + 
+				    (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*pow(Rtel,2)*cos(HA)*sin(HA)*sin(dec) +
+				     Rdec*Rtel*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) -
+				    2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) -
+				    Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) -
+							  2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) +
+							  Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) +
+							  Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) +
+									       2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) +
+							  Rdec*(-((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec)) +
+								pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) +
+				    cos(dec)*sin(dec)*(-(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec)) -
+						       2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) -
+									   pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) +
+						       Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) +
+									    sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) - 2*pow(Rdec,2)*sin(HA)*sin(phi))) +
 								  Rdec*Rtel*sin(HA)*sin(dec)*sin(2*phi))))))/
-	    (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) + 
+	    (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) +
 			 pow(cos(dec),2)*(pow(sin(HA),2) + pow(cos(HA),2)*pow(sin(phi),2)))) ;
 
 
@@ -386,33 +388,33 @@ double LDCutPierLineM1(double HA, double dec, double phi, double zd, double xd, 
 double LDCutPierLineP3(double HA, double dec, double phi, double zd, double xd, double Rdec, double Rtel, double Rpier)
 {
   double val= NAN;
-  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) - 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) - 
-     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) - 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) + 
-     Rpier*cos(HA)*(-(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi)) + 
-        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) - 
-        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) + 
+  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) -
+     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) -
+     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) -
+     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) +
+     Rpier*cos(HA)*(-(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi)) +
+        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) -
+        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) +
      Csc(HA)*Sec(dec)*sqrt(pow(Rpier,2)*pow(cos(dec),2)*pow(sin(HA),2)*
-        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) + 
+        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) +
           pow(Rdec,2)*pow(cos(phi),2)*pow(sin(dec),2)*
-           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*Rdec*Rtel*cos(HA)*sin(HA)*sin(dec) + 
-             pow(Rtel,2)*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) + 
-          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) - 
-          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) - 
-             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) + 
-             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) + 
-             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) + 
-                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) + 
-             Rdec*((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec) + 
-                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) + 
-          cos(dec)*sin(dec)*(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec) - 
-             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) - 
-                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) + 
-             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) - 
-                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) + 2*Rdec*Rtel*sin(HA)*sin(phi))) + 
+           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*Rdec*Rtel*cos(HA)*sin(HA)*sin(dec) +
+             pow(Rtel,2)*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) +
+          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) -
+          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) -
+             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) +
+             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) +
+             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) +
+                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) +
+             Rdec*((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec) +
+                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) +
+          cos(dec)*sin(dec)*(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec) -
+             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) -
+                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) +
+             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) -
+                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) + 2*Rdec*Rtel*sin(HA)*sin(phi))) +
                 pow(Rdec,2)*sin(HA)*sin(dec)*sin(2*phi))))))/
-   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) + 
+   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) +
 		pow(cos(dec),2)*(pow(sin(HA),2) + pow(cos(HA),2)*pow(sin(phi),2))));
 
   //  fprintf( stderr, "-x-xLDCutPierLineP3: WEST %+010.5f\n", val ) ;
@@ -421,33 +423,33 @@ double LDCutPierLineP3(double HA, double dec, double phi, double zd, double xd, 
 double LDCutPierLineM3(double HA, double dec, double phi, double zd, double xd, double Rdec, double Rtel, double Rpier)
 {
   double val= NAN;
-  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) - sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) + 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) - 
-     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) + 
-     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) + 
-     Rpier*cos(HA)*(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi) - 
-        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) - 
-        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) + 
+  val=  (Rdec*Rpier*xd*cos(phi)*sin(dec) - sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(cos(phi),2)*sin(dec) +
+     sqrt(pow(Rdec,2))*Rpier*Rtel*cos(dec)*pow(sin(HA),2)*sin(dec) -
+     Rdec*sqrt(pow(Rdec,2))*Rpier*cos(phi)*sin(HA)*sin(dec)*sin(phi) + sqrt(pow(Rdec,2))*Rpier*Rtel*cos(phi)*sin(HA)*sin(dec)*sin(phi) +
+     sqrt(pow(Rdec,2))*Rpier*Rtel*pow(cos(HA),2)*cos(dec)*sin(dec)*pow(sin(phi),2) +
+     Rpier*cos(HA)*(sqrt(pow(Rdec,2))*Rtel*pow(cos(dec),2)*cos(phi)*sin(phi) -
+        sqrt(pow(Rdec,2))*Rtel*cos(phi)*pow(sin(dec),2)*sin(phi) -
+        cos(dec)*(sqrt(pow(Rdec,2))*(Rdec - Rtel)*pow(cos(phi),2)*sin(HA) + Rdec*xd*sin(phi))) +
      Csc(HA)*Sec(dec)*sqrt(pow(Rpier,2)*pow(cos(dec),2)*pow(sin(HA),2)*
-        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) + 
+        (-(pow(Rdec,2)*pow(Rtel,2)*pow(cos(dec),4)*pow(cos(phi),2)*pow(sin(HA),2)) +
           pow(Rdec,2)*pow(cos(phi),2)*pow(sin(dec),2)*
-           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*pow(Rtel,2)*cos(HA)*sin(HA)*sin(dec) + 
-             Rdec*Rtel*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) - 
-          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) - 
-          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) - 
-             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) + 
-             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) + 
-             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) + 
-                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) + 
-             Rdec*(-((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec)) + 
-                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) + 
-          cos(dec)*sin(dec)*(-(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec)) - 
-             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) - 
-                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) + 
-             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) + 
-                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) - 2*pow(Rdec,2)*sin(HA)*sin(phi))) + 
+           (pow(Rpier,2) - pow(Rdec - Rtel,2)*pow(cos(HA),2) - 2*pow(Rtel,2)*cos(HA)*sin(HA)*sin(dec) +
+             Rdec*Rtel*sin(2*HA)*sin(dec) - pow(Rtel,2)*pow(sin(HA),2)*pow(sin(dec),2)) -
+          2*Rdec*Rtel*pow(cos(dec),3)*cos(phi)*sin(HA)*(-(sqrt(pow(Rdec,2))*xd*sin(HA)) + Rdec*(Rdec - Rtel)*sin(phi)) -
+          Rdec*pow(cos(dec),2)*(-2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(cos(HA),2)*sin(HA)*sin(phi) -
+             2*sqrt(pow(Rdec,2))*(Rdec - Rtel)*xd*pow(sin(HA),3)*sin(phi) +
+             Rdec*pow(Rdec - Rtel,2)*pow(sin(HA),4)*pow(sin(phi),2) +
+             Rdec*pow(sin(HA),2)*(-pow(Rpier,2) + pow(xd,2) + 2*pow(Rtel,2)*pow(cos(phi),2)*pow(sin(dec),2) +
+                2*pow(Rdec - Rtel,2)*pow(cos(HA),2)*pow(sin(phi),2)) +
+             Rdec*(-((Rdec - Rtel)*Rtel*pow(cos(phi),2)*sin(2*HA)*sin(dec)) +
+                pow(cos(HA),2)*(-pow(Rpier,2) + pow(Rdec - Rtel,2)*pow(cos(HA),2))*pow(sin(phi),2))) +
+          cos(dec)*sin(dec)*(-(Rdec*sqrt(pow(Rdec,2))*Rtel*xd*pow(cos(HA),2)*cos(phi)*sin(dec)) -
+             2*cos(HA)*cos(phi)*(pow(pow(Rdec,2),1.5)*xd*sin(HA) -
+                pow(Rdec,2)*(pow(Rdec,2) - pow(Rpier,2) - 2*Rdec*Rtel + pow(Rtel,2))*sin(phi)) +
+             Rdec*Rtel*(cos(phi)*(sqrt(pow(Rdec,2))*xd*sin(2*HA) +
+                   sin(dec)*(sqrt(pow(Rdec,2))*xd + sqrt(pow(Rdec,2))*xd*pow(sin(HA),2) - 2*pow(Rdec,2)*sin(HA)*sin(phi))) +
                 Rdec*Rtel*sin(HA)*sin(dec)*sin(2*phi))))))/
-   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) + 
+   (Rdec*Rpier*(pow(cos(phi),2)*pow(sin(dec),2) - 2*cos(HA)*cos(dec)*cos(phi)*sin(dec)*sin(phi) +
 		pow(cos(dec),2)*(pow(sin(HA),2) + pow(cos(HA),2)*pow(sin(phi),2))));
 
   //  fprintf( stderr, "X-X-LDCutPierLineM3: WEST %+010.5f\n", val ) ;

--- a/lib/xmlrpc++/XmlRpcValue.cpp
+++ b/lib/xmlrpc++/XmlRpcValue.cpp
@@ -12,7 +12,7 @@
 # include <string.h>
 #endif
 
-#include <math.h>
+#include <cmath>
 
 namespace XmlRpc
 {
@@ -360,7 +360,7 @@ namespace XmlRpc
 	std::string XmlRpcValue::doubleToXml() const
 	{
 		char buf[256];
-		if (isnan (_value.asDouble))
+		if (std::isnan (_value.asDouble))
 			strcpy (buf, "NaN");
 		else
 			snprintf(buf, sizeof(buf)-1, getDoubleFormat().c_str(), _value.asDouble);

--- a/src/camd/sbig.cpp
+++ b/src/camd/sbig.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * (USB) SBIG driver.
  * Copyright (C) 2004-2008 Petr Kubanek <petr@kubanek.net>
  *
@@ -17,6 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <cmath>
 #include <math.h>
 #include <netdb.h>
 #include <stdio.h>
@@ -215,7 +216,7 @@ int Sbig::startExposure ()
 	sep.left = chipUsedReadout->getYInt();
 	sep.height = chipUsedReadout->getHeightInt() / binningVertical ();
 	sep.width = chipUsedReadout->getWidthInt() / binningHorizontal ();
- 
+
 	ret = pcam->SBIGUnivDrvCommand (CC_START_EXPOSURE2, &sep, NULL);
 	return checkSbigHw (ret);
 }
@@ -404,7 +405,7 @@ SBIG_DEVICE_TYPE Sbig::getDevType ()
 int Sbig::initHardware ()
 {
 	setExposureMinMax (0, 655.35);
-	
+
 	tempSet->setMin (-100);
 	tempSet->setMax (50);
 	updateMetaInformations (tempSet);
@@ -625,7 +626,7 @@ int Sbig::camCoolHold ()
 	ret = fanState (TRUE);
 	if (ret)
 		return -1;
-	if (isnan (nightCoolTemp->getValueFloat ()))
+	if (std::isnan (nightCoolTemp->getValueFloat ()))
 		ret = setCoolTemp (-5);
 	else
 		ret = setCoolTemp (nightCoolTemp->getValueFloat ());

--- a/src/dome/bootes2.cpp
+++ b/src/dome/bootes2.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Dome driver for Bootes 2 station.
  * Copyright (C) 2005-2008 Stanislav Vitek
  * Copyright (C) 2008 Petr Kubanek <petr@kubanek.net>
@@ -171,7 +171,7 @@ Bootes2::getVolts (int subdevice, int channel, double &volts)
 		return -1;
 	}
 	volts = comedi_to_phys (data, rqn, max);
-	if (isnan (volts))
+	if (std::isnan (volts))
 	{
 		logStream (MESSAGE_ERROR) << "Cannot convert data from subdevice "
 			<< subdevice << " channel " << channel << " to physical units" << sendLog;
@@ -385,10 +385,10 @@ Bootes2::startClose ()
 	ret = updateStatus ();
 	if (ret)
 		return -1;
-	
+
 	if (swCloseLeft->getValueBool () && swCloseRight->getValueBool ())
 		return -1;
-	
+
 	return roofChange ();
 }
 

--- a/src/dome/rts2connbufweather.cpp
+++ b/src/dome/rts2connbufweather.cpp
@@ -209,7 +209,7 @@ Rts2ConnBufWeather::receive (rts2core::Block *block)
 		master->setRainWeather (rain);
 		master->setHumidity (rtOutsideHum);
 		master->setWindSpeed (windspeed);
-		if (!isnan (cloud))
+		if (!std::isnan (cloud))
 		{
 			master->setCloud (cloud);
 		}

--- a/src/sensord/bootes2.cpp
+++ b/src/sensord/bootes2.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Access data from Bootes 2 weather station.
  * Copyright (C) 2009,2011 Petr Kubanek <petr@kubanek.net>
  *
@@ -56,13 +56,13 @@ class Bootes2: public SensorWeather
 		const char *comediFile;
 
 		rts2core::ValueBool *raining;
-	
+
 		rts2core::ValueDoubleStat *tempMeas;
 		rts2core::ValueDoubleStat *humiMeas;
 
 		bool rainOnOff;
 		bool humiOnOff;
-		
+
 		rts2core::ValueDouble *humBad;
 		rts2core::ValueDouble *humGood;
 
@@ -160,7 +160,7 @@ int Bootes2::getVolts (int subdevice, int channel, double &volts)
 		return -1;
 	}
 	volts = comedi_to_phys (data, rqn, max);
-	if (isnan (volts))
+	if (std::isnan (volts))
 	{
 		logStream (MESSAGE_ERROR) << "Cannot convert data from subdevice " << subdevice << " channel " << channel << " to physical units" << sendLog;
 		return -1;
@@ -171,9 +171,9 @@ int Bootes2::getVolts (int subdevice, int channel, double &volts)
 int Bootes2::updateHumidity ()
 {
 	double hum;
-	
+
 	humiOnOff = !humiOnOff;
-	
+
 	if (getVolts (0, 0, hum))
 	{
 		comedi_dio_write (comediDevice, 2, 3, humiOnOff);
@@ -184,13 +184,13 @@ int Bootes2::updateHumidity ()
 	humiMeas->addValue (hum, LIFOSIZE);
 	humiMeas->calculate ();
 
-	
-	if (!isnan (humBad->getValueDouble ()) && humiMeas->getValueDouble () > humBad->getValueDouble ())
+
+	if (!std::isnan (humBad->getValueDouble ()) && humiMeas->getValueDouble () > humBad->getValueDouble ())
 	{
 		setWeatherTimeout (600, "humidity rised above humidity_bad");
 		comedi_dio_write (comediDevice, 2, 3, 1);
 	}
-	if (!isnan (humGood->getValueDouble ()) && humiMeas->getValueDouble () > humGood->getValueDouble () && getWeatherState () == false)
+	if (!std::isnan (humGood->getValueDouble ()) && humiMeas->getValueDouble () > humGood->getValueDouble () && getWeatherState () == false)
 	{
 		setWeatherTimeout (600, "humidity does not drop bellow humidity_good");
 		comedi_dio_write (comediDevice, 2, 3, 0);
@@ -215,7 +215,7 @@ int Bootes2::updateRain ()
 {
 	int ret=0;
 	double rv;
-	
+
 	rainOnOff = !rainOnOff;
 
 	ret = getVolts (0, 5, rv);
@@ -313,7 +313,7 @@ int Bootes2::info ()
 {
 	int ret;
 
-	ret = updateRain ();	
+	ret = updateRain ();
 
 	ret = updateTemperature ();
 	if (ret)
@@ -327,7 +327,7 @@ int Bootes2::info ()
 	 	logStream (MESSAGE_ERROR) << "Humidity measurement failed" << sendLog;
 		return -1;
 	}
-	
+
 	std::vector <double> vals;
 
 	for (int i = 0; i < 8; i++)

--- a/src/sensord/lpnhe.cpp
+++ b/src/sensord/lpnhe.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * LPNHE Paris LSST controll board (filter wheel, humidity measurements).
  * Copyright (C) 2009 Petr Kubanek <petr@kubanek.net>
  *
@@ -60,7 +60,7 @@ class LPNHE: public Sensor
 		rts2core::ValueBool *filterHomed;
 		rts2core::ValueBool *filterMoving;
 		rts2core::ValueBool *shutter;
-	
+
 		int filterChange (int num);
 
 		int homeFilter ();
@@ -258,7 +258,7 @@ int LPNHE::filterChange (int num)
 		if (comedi_dio_write (comediDevice, 2, 0, 1) != 1)
 		{
 			logStream (MESSAGE_ERROR) << "Cannot switch roof pulse to off, ignoring" << sendLog;
-		} 
+		}
 
 		// wait for moving becoming low
 		uint32_t value;
@@ -334,7 +334,7 @@ int LPNHE::getVolts (int subdevice, int channel, double &volts)
 		return -1;
 	}
 	volts = comedi_to_phys (data, rqn, max);
-	if (isnan (volts))
+	if (std::isnan (volts))
 	{
 		logStream (MESSAGE_ERROR) << "Cannot convert data from subdevice "
 			<< subdevice << " channel " << channel << " to physical units" << sendLog;

--- a/src/ucac5/search.cpp
+++ b/src/ucac5/search.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * UCAC5 indexing application
  * Copyright (C) 2018 Petr Kubanek <petr@kubanek.net>
  *
@@ -45,13 +45,13 @@ class UCAC5Search:public rts2core::App
 		UCAC5Search (int argc, char **argv);
 
 		virtual int run();
-	
+
 	protected:
 		virtual int processOption (int opt);
 		virtual int processArgs (const char *arg);
 
 		virtual void usage ();
-	
+
 	private:
 		std::string radec;
 		double ra;
@@ -74,7 +74,7 @@ int UCAC5Search::run()
 	int ret = init();
 	if (ret)
 		return ret;
-	if (isnan(ra) || isnan(dec) || isnan(minRad) || isnan(maxRad))
+	if (std::isnan(ra) || std::isnan(dec) || std::isnan(minRad) || std::isnan(maxRad))
 	{
 		std::cerr << "you must provide ra dec min max, please see -h for details" << std::endl;
 		return -2;


### PR DESCRIPTION
Fixes compilation on Ubuntu 16, which uses GCC 5.4 (supports C++11, but disables it by default).
Complications with "isnan" on different versions are described e.g. here - https://stackoverflow.com/questions/39130040/cmath-hides-isnan-in-math-h-in-c14-c11

Ubuntu 16 still does not detect proper CXX flags to enable C++11, so you have to configure like that:
CXX="g++ -std=c++11" ./configure  