### PR TITLE
queCommand should ONLY send command immediately in CONN_AUTH_OK (for devices) or CONN_CONNECTED (for clients?..) states, or it may block queSend and therefore device authorization in centrald

### DIFF
--- a/lib/rts2/connection.cpp
+++ b/lib/rts2/connection.cpp
@@ -1221,11 +1221,7 @@ int Connection::queCommand (Command * cmd)
 	std::cout << "Connection::queCommand " << cmd->getText () << " runningCommand " << runningCommand << " queu size " << commandQue.size () << std::endl;
 	#endif
 	cmd->setConnection (this);
-	if (runningCommand
-		|| isConnState (CONN_CONNECTING)
-		|| isConnState (CONN_INPROGRESS)
-		|| isConnState (CONN_AUTH_PENDING)
-		|| isConnState (CONN_UNKNOW))
+	if (runningCommand || (getConnState () != CONN_AUTH_OK && getConnState () != CONN_CONNECTED))
 	{
 		commandQue.push_back (cmd);
 		return 1;

--- a/lib/rts2/connfork.cpp
+++ b/lib/rts2/connfork.cpp
@@ -76,7 +76,7 @@ ConnFork::ConnFork (rts2core::Block *_master, const char *_exe, bool _fillConnEn
 			// Non-empty token
 			if (count == 0)
 			{
-				exePath = new char[pos - start];
+				exePath = new char[pos - start + 1];
 				strcpy (exePath, start);
 			}
 			else
@@ -105,7 +105,7 @@ ConnFork::~ConnFork ()
 		close (sockerr);
 	if (sockwrite > 0)
 		close (sockwrite);
-	delete[]exePath;
+	delete[] exePath;
 }
 
 int ConnFork::writeToProcess (const char *msg)


### PR DESCRIPTION
Petr, does it sound reasonable? Is there any corner case (device-device connections or so) where it is necessary to send commands using queCommand (and not queSend) in other states?

This fixes a rather nasty and difficult to track down problem when at least HTTPD and DOME sometimes fail to start using  'rts2-start all'. The reason is that if their original connection attempt fail somehow, on re-connect they will block if there is already a command in the queue (e.g. 'weather_update' for DOME issued as there is no centrald connected and it tries to set bad weather), which will never finish as the connection is not yet authorized.