### PR TITLE
Postgres and install packages revision plus some debugging and tuning

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,25 +9,24 @@ Instalation from Git
 ====================
 
    You will need following packages (apt-get install on Debian based systems
-   should install them).
+   should install them), updated in May 2023:
 
-   git postgresql postgresql-server-dev libecpg-dev automake libtool
-   libcfitsio3-dev libnova-dev libecpg-dev gcc g++ libncurses5-dev
+   git postgresql postgresql-server-dev-all libecpg-dev automake libtool
+   libcfitsio-dev libnova-dev gcc g++ libncurses5-dev
    libgraphicsmagick++1-dev libx11-dev docbook-xsl xsltproc libxml2-dev libarchive-dev
-   libjson-glib-dev libsoup2.4-dev pkg-config
+   libjson-glib-dev libsoup2.4-dev pkg-config libcurl4-gnutls-dev libsnmp-dev
 
-   Please note that postgresql-server-dev is actually postgresql-server-dev-8.3
-   on Ubuntu 9.04, postgresql-server-dev-8.4 on 9.10 and postgresql-server-dev-9.5
-   on 16.04.
+   For using the e.g. gxccd driver, you will need also this package:
+   libusb-1.0-0-dev
 
    WCS libraries are needed for database and for rts2-f2j binary. If you wish
-   to use them, you must manually install WCS using folowing steps. Just before
-   you begin, important note: on Ubuntu 64bit installations, you need to
-   compile wcs with -fPIC CFLAG.
+   to use them, you must either use a package (again, for Debian based systems):
 
-   Note that as of April 2016 libwcstools-dev is available in both Debian and
-   Ubuntu and should be installed via the package manager, rather than the
-   process described here.
+   libwcstools-dev
+
+   (which is a preferred way), or to manually install WCS using folowing steps.
+   Just before you begin, important note: on Ubuntu 64bit installations, you need to
+   compile wcs with -fPIC CFLAG.
 
 user@host:wget http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.4.tar.gz
 user@host:tar xzf wcstools-3.9.4.tar.gz

--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ AC_ARG_WITH(xml2,
 	*) XML_CONFIG=${withval} ;;
 esac],[XML_CONFIG=xml2-config])
 AC_MSG_CHECKING(looking for xml2 library)
-AS_IF(["${XML_CONFIG}" --libs print > /dev/null 2>&1], [
+AS_IF(["${XML_CONFIG}" --libs > /dev/null 2>&1], [
 	XMLVERS=`${XML_CONFIG} --version`
 	LIBXML_LIBS=`${XML_CONFIG} --libs`
 	LIBXML_CFLAGS=`${XML_CONFIG} --cflags`

--- a/lib/rts2script/elementwaitfor.cpp
+++ b/lib/rts2script/elementwaitfor.cpp
@@ -71,7 +71,6 @@ int ElementSleep::defnextCommand (rts2core::DevClient * client, rts2core::Comman
 
 int ElementSleep::idle ()
 {
-	sec = NAN;
 	return NEXT_COMMAND_NEXT;
 }
 

--- a/src/sensord/aws-mlab.cpp
+++ b/src/sensord/aws-mlab.cpp
@@ -336,7 +336,7 @@ int AWSmlab::initHardware ()
 		triggerWindGood->setValueDouble (triggerWindGoodPO);
 	}
 
-	AWSConn = new rts2core::ConnSerial (device_file, this, rts2core::BS9600, rts2core::C8, rts2core::NONE, 10);
+	AWSConn = new rts2core::ConnSerial (device_file, this, rts2core::BS9600, rts2core::C8, rts2core::NONE, 40);
 	AWSConn->setDebug (getDebug ());
 	int ret = AWSConn->init ();
 	if (ret)

--- a/src/sql/create/tables.sql
+++ b/src/sql/create/tables.sql
@@ -194,7 +194,7 @@ CONSTRAINT images_prim_key PRIMARY KEY (obs_id, img_id)
 
 CREATE TABLE counts ( 
 	obs_id		integer REFERENCES observations(obs_id),
-	count_date	abstime NOT NULL,
+	count_date	timestamp with time zone NOT NULL,
 	count_usec	integer NOT NULL,
 	count_value	integer NOT NULL,
 	count_exposure	float,

--- a/src/sql/create/typ_wcs.sql
+++ b/src/sql/create/typ_wcs.sql
@@ -1,10 +1,10 @@
-CREATE FUNCTION wcs_in (opaque) -- OR REPLACE
+CREATE TYPE wcs;
+
+CREATE FUNCTION wcs_in (cstring) -- OR REPLACE
   RETURNS wcs AS 'pg_wcs.so','wcs_in' LANGUAGE 'c';
 
-CREATE FUNCTION wcs_out (opaque) -- OR REPLACE
-  RETURNS opaque AS 'pg_wcs.so', 'wcs_out' LANGUAGE 'c';
-
--- poprve se vypise varovani, ze typ neni
+CREATE FUNCTION wcs_out (wcs) -- OR REPLACE
+  RETURNS cstring AS 'pg_wcs.so', 'wcs_out' LANGUAGE 'c';
 
 CREATE TYPE wcs (
   internallength = 220,  -- zjisti si laskave presnou velikost, az to budes mit hotove

--- a/src/sql/create/typ_wcs2.sql
+++ b/src/sql/create/typ_wcs2.sql
@@ -1,9 +1,11 @@
 -- wcs2 type
-CREATE FUNCTION wcs2_in (opaque) -- OR REPLACE
+CREATE TYPE wcs2;
+
+CREATE FUNCTION wcs2_in (cstring) -- OR REPLACE
   RETURNS wcs2 AS 'pg_wcs2.so','wcs2_in' LANGUAGE 'c';
 
-CREATE FUNCTION wcs2_out (opaque) -- OR REPLACE
-  RETURNS opaque AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
+CREATE FUNCTION wcs2_out (wcs2) -- OR REPLACE
+  RETURNS cstring AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
 
 CREATE TYPE wcs2 (
   internallength = 80,

--- a/src/sql/create/views.sql
+++ b/src/sql/create/views.sql
@@ -74,22 +74,3 @@ WHERE
 ORDER BY
 	count_date DESC;
 
-CREATE VIEW images_path AS
-SELECT
-	img_id,
-	imgpath (med_id, epoch_id, mount_name, camera_name, images.obs_id, tar_id, abstime(img_date)) as img_path,
-	img_date,
-	round(img_exposure/100.0,2) as img_exposure_sec,
-	round(img_temperature/10.0,2) as img_temperature_deg,
-	img_filter,
-	imgrange (astrometry) as img_range,
-	images.obs_id,
-	observations.tar_id,
-	camera_name
-FROM
-	images,
-	observations
-WHERE
-	images.obs_id = observations.obs_id
-ORDER BY
-	img_id;

--- a/src/sql/drop/functions.sql
+++ b/src/sql/drop/functions.sql
@@ -1,13 +1,13 @@
-DROP FUNCTION night_num (timestamp with time zone) RETURNS double precision;
+DROP FUNCTION night_num (timestamp with time zone);
 
-DROP FUNCTION isinwcs (float8, float8, wcs) RETURNS bool;
+DROP FUNCTION isinwcs (float8, float8, wcs);
 
-DROP FUNCTION imgrange (wcs) RETURNS varchar;
+DROP FUNCTION imgrange (wcs);
 
-DROP FUNCTION imgpath(integer, integer, varchar(8), varchar(8), integer, integer, abstime) RETURNS varchar(100);
+DROP FUNCTION imgpath(integer, integer, varchar(8), varchar(8), integer, integer, abstime);
 
-DROP FUNCTION img_fits_name (timestamp, integer) RETURNS varchar (30);
+DROP FUNCTION img_fits_name (timestamp, integer);
 
-DROP FUNCTION dark_name(integer, integer, timestamp, integer,   integer, varchar(8)) RETURNS varchar(250);
+DROP FUNCTION dark_name(integer, integer, timestamp, integer, integer, varchar(8));
 
-DROP FUNCTION ell_update (varchar (150), float4, float4, float4, float4, float4, float4, float8, float4, float4) RETURNS integer;
+DROP FUNCTION ell_update (varchar (150), float4, float4, float4, float4, float4, float4, float8, float4, float4);

--- a/src/sql/drop/typ_wcs.sql
+++ b/src/sql/drop/typ_wcs.sql
@@ -1,3 +1,3 @@
 DROP TYPE wcs; -- CASCADE
-DROP FUNCTION wcs_in (opaque);
-DROP FUNCTION wcs_out (opaque);
+DROP FUNCTION wcs_in (cstring);
+DROP FUNCTION wcs_out (wcs);

--- a/src/sql/drop/typ_wcs2.sql
+++ b/src/sql/drop/typ_wcs2.sql
@@ -1,3 +1,3 @@
 DROP TYPE wcs2; -- CASCADE
-DROP FUNCTION wcs2_in (opaque);
-DROP FUNCTION wcs2_out (opaque);
+DROP FUNCTION wcs2_in (cstring);
+DROP FUNCTION wcs2_out (wcs2);

--- a/src/sql/update/rel_0_5_1.sql
+++ b/src/sql/update/rel_0_5_1.sql
@@ -21,7 +21,7 @@ CREATE TABLE targets_users (
 CREATE TABLE airmass_cal_images (
 	air_airmass_start  float NOT NULL,
 	air_airmass_end    float NOT NULL,
-	air_last_image     timestamp NOT NULL default abstime (0),
+	air_last_image     timestamp NOT NULL default to_timestamp (0),
 	-- referenced image - can be null
 	obs_id             integer,
 	img_id             integer,

--- a/src/sql/update/rel_0_5_2.sql
+++ b/src/sql/update/rel_0_5_2.sql
@@ -18,11 +18,11 @@ CREATE OR REPLACE FUNCTION ln_angular_separation (float8, float8, float8, float8
   RETURNS float8 AS 'pg_astrolib.so', 'ln_angular_separation' LANGUAGE 'c';
 
 -- wcs2 type
-CREATE FUNCTION wcs2_in (opaque) -- OR REPLACE
+CREATE FUNCTION wcs2_in (cstring) -- OR REPLACE
   RETURNS wcs2 AS 'pg_wcs2.so','wcs2_in' LANGUAGE 'c';
 
-CREATE FUNCTION wcs2_out (opaque) -- OR REPLACE
-  RETURNS opaque AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
+CREATE FUNCTION wcs2_out (cstring) -- OR REPLACE
+  RETURNS cstring AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
 
 CREATE TYPE wcs2 (
   internallength = 80,

--- a/src/sql/update/rel_1_0_1.sql
+++ b/src/sql/update/rel_1_0_1.sql
@@ -1,0 +1,39 @@
+-- Take care of lost support for long-deprecated properties - 'abstime' type and 'opaque' type in function's definition
+CREATE OR REPLACE FUNCTION wcs_in (cstring)
+  RETURNS wcs AS 'pg_wcs.so','wcs_in' LANGUAGE 'c';
+
+CREATE OR REPLACE FUNCTION wcs_out (wcs)
+  RETURNS cstring AS 'pg_wcs.so', 'wcs_out' LANGUAGE 'c';
+
+CREATE OR REPLACE FUNCTION wcs2_in (cstring)
+  RETURNS wcs2 AS 'pg_wcs2.so','wcs2_in' LANGUAGE 'c';
+
+CREATE OR REPLACE FUNCTION wcs2_out (wcs2)
+  RETURNS cstring AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
+
+
+-- we have to drop this view temporarily, just to be able to alter the "counts" table
+DROP VIEW targets_counts;
+
+ALTER TABLE counts ALTER COLUMN count_date TYPE timestamp with time zone;
+
+CREATE VIEW targets_counts AS
+SELECT
+        targets.tar_id,
+        counts.*
+FROM
+        targets, counts, observations
+WHERE
+        targets.tar_id = observations.tar_id
+    AND observations.obs_id = counts.obs_id
+ORDER BY
+        count_date DESC;
+
+
+ALTER TABLE airmass_cal_images ALTER COLUMN air_last_image TYPE timestamp with time zone;
+ALTER TABLE airmass_cal_images ALTER COLUMN air_last_image SET default to_timestamp (0);
+
+
+-- and also, remove this obviously long-forgotten relic
+DROP VIEW images_path;
+

--- a/src/sql/update/wcs2.sql
+++ b/src/sql/update/wcs2.sql
@@ -1,9 +1,9 @@
 -- wcs2 type
-CREATE FUNCTION wcs2_in (opaque) -- OR REPLACE
+CREATE FUNCTION wcs2_in (cstring) -- OR REPLACE
   RETURNS wcs2 AS 'pg_wcs2.so','wcs2_in' LANGUAGE 'c';
 
-CREATE FUNCTION wcs2_out (opaque) -- OR REPLACE
-  RETURNS opaque AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
+CREATE FUNCTION wcs2_out (wcs2) -- OR REPLACE
+  RETURNS cstring AS 'pg_wcs2.so', 'wcs2_out' LANGUAGE 'c';
 
 CREATE TYPE wcs2 (
   internallength = 80,


### PR DESCRIPTION
Especially the postgres (sql scripts) revision and patch (solving non-compatibility with recent versions of psql) might be useful, I don't want to delay it unnecessarily. I didn't test the patch on older versions of postgres, however it should solve the problems with migrating to a never version. (This solves problems I discovered during the upgrade, I had to manually edit the dump etc, applying this patch before an upgrade should prevent these problems.)
The patch should be harmless, but as usual, I suggest creating a dump before applying it :-).
In every case, these commits solve problems for new DB installations.