### PR TITLE
Allow targets without coordinates & use them in targets.sql

### DIFF
--- a/include/rts2db/targetres.h
+++ b/include/rts2db/targetres.h
@@ -33,4 +33,11 @@
  */
 rts2db::Target *createTargetByString (std::string tar_string, bool debug);
 
+/**
+ * Return new target object, with null position.
+ *
+ * @return new target object. Caller must deallocate target object (delete it).
+ */
+rts2db::Target *createEmptyTarget ();
+
 #endif // __RTS2_TARGETRES__

--- a/lib/rts2db/targetres.cpp
+++ b/lib/rts2db/targetres.cpp
@@ -95,3 +95,13 @@ Target *createTargetByString (std::string tar_string, bool debug)
 		return rtar;
 	}
 }
+
+Target *createEmptyTarget()
+{
+	ConstTarget *constTarget = new ConstTarget ();
+
+	constTarget->setTargetName("RTS2_EMPTY");
+	constTarget->setPosition(NAN, NAN);
+	constTarget->setTargetType (TYPE_OPORTUNITY);
+	return constTarget;
+}

--- a/man/rts2-newtarget.xml
+++ b/man/rts2-newtarget.xml
@@ -55,6 +55,7 @@
       <arg choice="opt"><option>-m</option></arg>
       <arg choice="opt"><option>-r</option> <replaceable class="parameter">radius</replaceable></arg>
       <arg choice="opt"><option>-f</option></arg>
+      <arg choice="opt"><option>-n</option></arg>
       <arg choice="opt"><option>--pi</option> <replaceable class="parameter">PI name</replaceable></arg>
       <arg choice="opt"><option>--program</option> <replaceable class="parameter">program name</replaceable></arg>
       &dbapp;
@@ -157,6 +158,14 @@
 	    existing target etc.
 	  </para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-n</option></term>
+        <listitem>
+          <para>
+            No coordinates. Don't move the telescope.
+          </para>
+        </listitem>
       </varlistentry>
       <varlistentry>
         <term><option>--pi <replaceable class="parameter">PI name</replaceable></option></term>

--- a/src/db/newtarget.cpp
+++ b/src/db/newtarget.cpp
@@ -19,6 +19,7 @@
 
 #include "rts2db/appdb.h"
 #include "rts2db/target.h"
+#include "rts2db/targetres.h"
 #include "rts2db/targetset.h"
 #include "configuration.h"
 #include "libnova_cpp.h"
@@ -51,6 +52,7 @@ class Rts2NewTarget:public Rts2TargetApp
 		int n_tar_id;
 		bool tryMatch;
 		bool forcedRun;
+        	bool nullCoords;
 		const char *n_tar_name;
 		const char *n_tar_ra_dec;
 		double radius;
@@ -66,6 +68,7 @@ Rts2NewTarget::Rts2NewTarget (int in_argc, char **in_argv):Rts2TargetApp (in_arg
 	n_tar_id = -1;
 	tryMatch = false;
 	forcedRun = false;
+	nullCoords = false;
 	n_tar_name = NULL;
 	n_tar_ra_dec = NULL;
 
@@ -78,6 +81,7 @@ Rts2NewTarget::Rts2NewTarget (int in_argc, char **in_argv):Rts2TargetApp (in_arg
 	addOption ('m', NULL, 0, "try to match target name and RA DEC");
 	addOption ('r', NULL, 2, "radius for target checks");
 	addOption ('f', NULL, 0, "force run, don't ask questions about target overwrite");
+	addOption ('n', NULL, 0, "no coordinates, don't move the telescope");
 
 	addOption (OPT_PI_NAME, "pi", 1, "set PI name");
 	addOption (OPT_PROGRAM_NAME, "program", 1, "set program name");
@@ -102,6 +106,8 @@ void Rts2NewTarget::usage ()
 		<< "  " << getAppName () << " 1003 NGC567 '20:10:11 +11:14:15'" << std::endl
 		<< "Same as above, but don't bug user with questions:" << std::endl
 		<< "  " << getAppName () << " -f 1003 NGC567 '20:10:11 +11:14:15'" << std::endl
+		<< "To enter new target called Custom_Routine1, with ID 1003 that won't move the telescope:" << std::endl
+		<< "  " << getAppName () << " -n 1003 Custom_Routine1" << std::endl
 		<< std::endl;
 }
 
@@ -124,6 +130,9 @@ int Rts2NewTarget::processOption (int in_opt)
 			break;
 		case 'f':
 			forcedRun = true;
+			break;
+		case 'n':
+			nullCoords = true;
 			break;
 		case OPT_PI_NAME:
 			n_pi = optarg;
@@ -256,6 +265,12 @@ int Rts2NewTarget::doProcessing ()
 	if (!std::isnan (radius))
 		t_radius = radius;
 	int ret;
+
+	if (nullCoords) {
+		target = createEmptyTarget();
+		ret = 0;
+	}
+	else
 	// ask for target name..
 	if (n_tar_ra_dec == NULL)
 	{

--- a/src/sql/data/targets.sql
+++ b/src/sql/data/targets.sql
@@ -1,14 +1,14 @@
 -- standart targets (tar_id < 100)
 
 COPY targets (tar_id, type_id, tar_name, tar_ra, tar_dec, tar_comment, tar_enabled, tar_priority, tar_bonus, tar_bonus_time) FROM stdin;
-1	d	Dark frames	0	0	Used to produce darks	t	0	0	\N
-2	f	Flat frames	0	0	Used to produce flatfields	t	0	0	\N
-3	o	Focusing frames	0	0	Used to focusc cameras	t	0	0	\N
-4	m	Default model	0	0	Used to model get enought pictures for mount model	t	0	0	\N
-6	c	Master calibration target	0	0	Used to calibration frames	t	0	0	\N
-7	p	Master plan	0	0	Observe by plan	t	1	0	\N
-10	W	Swift FOV	0	0	Swift Field of View, based on GCN	t	0	0	\N
-11	I	Integral FOV	0	0	Integral Field of View, based on GCN	t	0	0	\N
+1	d	Dark frames	\N	\N	Used to produce darks	t	0	0	\N
+2	f	Flat frames	\N	\N	Used to produce flatfields	t	0	0	\N
+3	c	Focusing frames	\N  \N	Used to focusc cameras	t	0	0	\N
+4	m	Default model	\N	\N	Used to model get enought pictures for mount model	t	0	0	\N
+6	c	Master calibration target	\N	\N	Used to calibration frames	t	0	0	\N
+7	p	Master plan	\N	\N	Observe by plan	t	1	0	\N
+10	W	Swift FOV	\N	\N	Swift Field of View, based on GCN	t	0	0	\N
+11	I	Integral FOV	\N	\N	Integral Field of View, based on GCN	t	0	0	\N
 \.
 
 COPY target_model (tar_id, alt_start, alt_stop, alt_step, az_start, az_stop, az_step, noise, step) FROM stdin;


### PR DESCRIPTION
As the commits messages say, this merge request adds the option in rts2-newtarget to create targets without a position, which means the telescope won't move. This is particularly useful when using scripts where you don't know the object position beforehand.

Also, the targets in targets.sql are now using null instead of 0 as a coordinate since (0, 0) is a valid position in the sky, and sometimes, the telescope will move to (0, 0) (such as with the focusing target).