### PR TITLE
sql: data: Fix SQL data install dir

### DIFF
--- a/src/sql/data/Makefile.am
+++ b/src/sql/data/Makefile.am
@@ -1,3 +1,3 @@
-sqldatadir = ${datadir}/doc/@PACKAGE@/sql
+sqldatadir = ${datadir}/doc/@PACKAGE@/sql/data
 
 dist_sqldata_DATA = init.sql targets.sql dummy.sql landolt.sql planets.sql flats_iac.sql


### PR DESCRIPTION
When building as a package, the sql files are installed at the same level as rts2-builddb instead of inside data/. This appears to be just a mistake.