### PR TITLE
python: Fix focusing

### DIFF
--- a/python/rts2/focusing.py
+++ b/python/rts2/focusing.py
@@ -167,7 +167,7 @@ class Focusing (scriptcomm.Rts2Comm):
 				min_fwhm = fwhm[x]
 		return self.tryFit(defaultFit)
 
-	def findBestFWHM(self,tries,defaultFit=H3,min_stars=95,ds9display=False,threshold=2.7,deblendmin=0.03):
+	def __sexFindFWHM(self,tries,defaultFit=H3,min_stars=95,ds9display=False,threshold=2.7,deblendmin=0.03):
 		# X is FWHM, Y is offset value
 		self.focpos=[]
 		self.fwhm=[]
@@ -184,12 +184,12 @@ class Focusing (scriptcomm.Rts2Comm):
 				self.log('W','offset {0}: {1}'.format(k,ex))
 				continue
 			self.log('I','offset {0} fwhm {1} with {2} stars'.format(k,fwhm,nstars))
-			focpos.append(k)
-			fwhm.append(fwhm)
+			self.focpos.append(k)
+			self.fwhm.append(fwhm)
 			if (fwhm_min is None or fwhm < fwhm_min):
-				fwhm_MinimumX = k
+				self.fwhm_MinimumX = k
 				fwhm_min = fwhm
-		return focpos,fwhm,fwhm_min,fwhm_MinimumX
+		return self.focpos,self.fwhm,fwhm_min,self.fwhm_MinimumX
 
 	def __sepFindFWHM(self,tries):
 		from astropy.io import fits

--- a/python/rts2/sextractor.py
+++ b/python/rts2/sextractor.py
@@ -39,7 +39,7 @@ import traceback
 
 class Sextractor:
 	"""Class for a catalogue (SExtractor result)"""
-	def __init__(self, fields=['NUMBER', 'FLUXERR_ISO', 'FLUX_AUTO', 'X_IMAGE', 'Y_IMAGE', 'MAG_BEST', 'FLAGS', 'CLASS_STAR', 'FWHM_IMAGE', 'A_IMAGE', 'B_IMAGE','EXT_NUMBER'], sexpath='sextractor', sexconfig='/usr/share/sextractor/default.sex', starnnw='/usr/share/sextractor/default.nnw', threshold=2.7, deblendmin = 0.03, saturlevel=65535, verbose=False):
+	def __init__(self, fields=['NUMBER', 'FLUXERR_ISO', 'FLUX_AUTO', 'X_IMAGE', 'Y_IMAGE', 'MAG_BEST', 'FLAGS', 'CLASS_STAR', 'FWHM_IMAGE', 'A_IMAGE', 'B_IMAGE','EXT_NUMBER'], sexpath='sex', sexconfig='/usr/share/sextractor/default.sex', starnnw='/usr/share/sextractor/default.nnw', threshold=2.7, deblendmin = 0.03, saturlevel=65535, verbose=False):
 		self.sexpath = sexpath
 		self.sexconfig = sexconfig
 		self.starnnw = starnnw
@@ -96,11 +96,11 @@ class Sextractor:
 
 	def sortObjects(self,col):
 		"""Sort objects by given collumn."""
-		self.objects.sort(cmp=lambda x,y: cmp(x[col],y[col]))
+		self.objects.sort(key=lambda x: x[col])
 
 	def reverseObjects(self,col):
 		"""Reverse sort objects by given collumn."""
-		self.objects.sort(cmp=lambda x,y: cmp(x[col],y[col]))
+		self.objects.sort(key=lambda x: x[col])
 		self.objects.reverse()
 
 	def filter_galaxies(self,limit=0.2):
@@ -132,7 +132,7 @@ class Sextractor:
 		try:
 			# sort by magnitude
 			i_mag_best = self.get_field('MAG_BEST')
-			obj.sort(cmp=lambda x,y: cmp(x[i_mag_best],y[i_mag_best]))
+			obj.sort(key=lambda x: x[i_mag_best])
 			fwhmlist = []
 
 			a = 0


### PR DESCRIPTION
The `__sexFindFWHM` function was accidentally renamed at ( 3adf817 ), giving as a result, no _`_sexFindFWHM` function and two `findBestFWHM` functions.

Also, sextractor class is updated for python 3.