### PR TITLE
Use standard lock file logic for multidev

### DIFF
--- a/include/multidev.h
+++ b/include/multidev.h
@@ -56,6 +56,7 @@ class MultiBase:public Daemon
 		void addDevice (Device *dev);
 		virtual int init ();
 		virtual int run ();
+    		virtual void initLockFile () { setLockFile (std::string (getLockPrefix ()) + std::string (multi_name)); }
 
 	protected:
 		virtual int processOption (int opt);

--- a/lib/rts2/multidev.cpp
+++ b/lib/rts2/multidev.cpp
@@ -127,11 +127,6 @@ int MultiBase::init ()
 	if (ret)
 		exit (ret);
 
-	std::string s = std::string (getLockPrefix ()) + multi_name;
-	setLockFile (s.c_str ());
-	ret = checkLockFile ();
-	if (ret)
-		return ret;
 	return lockFile ();
 }
 


### PR DESCRIPTION
Multidev was left behind when 767c76840737121bbd435b2d443a48c178e0081e modified the lock file logic as it doesn't inherit from Device, so the lock file path was empty and RTS2 would report it as always running.