### PR TITLE
Don't try to close the dome if already closed after bad weather

### DIFF
--- a/lib/rts2/dome.cpp
+++ b/lib/rts2/dome.cpp
@@ -357,7 +357,9 @@ int Dome::closeDomeWeather ()
 	{
 		if (domeAutoClose == NULL || domeAutoClose->getValueBool () == true)
 		{
-			logStream (MESSAGE_DEBUG) << "closeDomeWeather: domeCloseStart" << sendLog;
+			if (isClosed() != -2) {
+				logStream(MESSAGE_DEBUG) << "closeDomeWeather: domeCloseStart" << sendLog;
+			}
 			ret = domeCloseStart ();
 		}
 		setMasterStandby ();


### PR DESCRIPTION
According to isClosed docs: 

> It is called also outside of the closing sequence, to check if dome is closed when bad weather arrives.

Right now, I get a lot of "closeDomeWeather: domeCloseStart" spam in the logs when it's daytime and the weather station reports bad weather.

This commit avoids all that spam and will only log (and try to close the dome) if it's not closed.