### PR TITLE
monitor: Fix backspace detection for some terminals

### DIFF
--- a/src/monitor/ncomwin.cpp
+++ b/src/monitor/ncomwin.cpp
@@ -42,6 +42,7 @@ keyRet NComWin::injectKey (int key)
 	{
 		case KEY_BACKSPACE:
 		case 127:
+		case '\b':
 			getyx (comwin, y, x);
 			mvwdelch (comwin, y, x - 1);
 			break;

--- a/src/monitor/nwindowedit.cpp
+++ b/src/monitor/nwindowedit.cpp
@@ -74,6 +74,7 @@ keyRet NWindowEdit::injectKey (int key)
 	{
 		case KEY_BACKSPACE:
 		case 127:
+		case '\b':
 			getyx (getWriteWindow (), y, x);
 			mvwdelch (getWriteWindow (), y, x - 1);
 			return RKEY_HANDLED;


### PR DESCRIPTION
In my case, using MobaXTerm on Windows, I was not able to delete characters from the monitor edit boxes. Adding \b does the trick.