### PR TITLE
newtarget: Ask for target name if none given

### DIFF
--- a/src/db/newtarget.cpp
+++ b/src/db/newtarget.cpp
@@ -294,6 +294,12 @@ int Rts2NewTarget::doProcessing ()
 	if (tryMatch)
 	{
 		rts2db::TargetSet ts;
+		if (n_tar_name == NULL)
+		{
+			std::string target_name;
+			askForString ("Target NAME", target_name);
+			n_tar_name = target_name.c_str();
+		}
 		ts.loadByName (n_tar_name, true);
 		if (ts.size () == 1)
 		{


### PR DESCRIPTION
When calling rts2-newtarget with -m, the user is expected to provide the coordinates and name when calling the command. However, if called from interactive mode, it will crash because n_tar_name is null. Instead of failing, ask for the target name.

P.S: I don't seem to be able to merge the other merge requests, maybe someone can help.