### PR TITLE
Fix TLETarget getPosition method

### DIFF
--- a/lib/rts2db/tletarget.cpp
+++ b/lib/rts2db/tletarget.cpp
@@ -76,7 +76,7 @@ void TLETarget::getPosition (struct ln_equ_posn *pos, double JD)
 
 	double r_s, r_c;
 
-	lat_alt_to_parallax (ln_deg_to_rad (observer->lat), obs_altitude * 1000, &r_c, &r_s);
+	lat_alt_to_parallax (ln_deg_to_rad (observer->lat), obs_altitude, &r_c, &r_s);
 
 	observer_cartesian_coords (JD, ln_deg_to_rad (observer->lng), r_c, r_s, observer_loc);
 


### PR DESCRIPTION
Altitude multiplied by 1000 gave a wrong result. This is showing an incorrect position at rts2-targetinfo, although the telescope is able to observe it fine as it's getting the position from Telescope::calculateTLE.

Here's an example on how to reproduce it:

- Set observatory position to W57 (-29, -70)
- Create the following TLE target:
```
1 38077U 12006A   24294.27170217 -.00000040  00000-0 -65323-5 0  9992
2 38077  69.4895 245.4944 0011374 256.6795 103.2963 12.54931718581173
```
- Ask for the position of the object in the following UTC date: 2024-10-21T08:27:14.765
- RTS2 returns:
```
~>  rts2-targetinfo -d 2024-10-21T08:24:14UT 49001
49001 B 23:11:03.351 +49:50:58.80 +08:24 nan  -26 45 26.49 134 19 32.16 setting    12006A
```
With alt -26. This is wrong, the following Python script can confirm:
```
from skyfield.api import wgs84, EarthSatellite, load

ts = load.timescale()
lasilla = wgs84.latlon(-29, -70)
line1 = '1 38077U 12006A   24294.27170217 -.00000040  00000-0 -65323-5 0  9992'
line2 = '2 38077  69.4895 245.4944 0011374 256.6795 103.2963 12.54931718581173'
lares = EarthSatellite(line1, line2, 'LARES', ts)
print(lares)

difference = lares - lasilla
topocentric = difference.at(ts.utc(2024, 10, 21, 8, 27, 14))
alt, az, distance = topocentric.altaz()
ra, dec, distance = topocentric.radec()

print(f'Alt: {alt}, Az: {az}')
print(f'Ra: {ra}, Dec: {dec}')
```
Alt: 24deg 51' 51.4", Az: 300deg 02' 23.1"
Ra: 02h 14m 17.65s, Dec: +11deg 02' 07.6"

Which matches the RTS2 log:
`2024-10-21T08:27:14.765 UTC T0 4100 moving from 11:49:01.282 -067:02:10.11 (altaz +334:10:55.13 +026:23:52.92) to 02:21:58.254 +011:56:43.56 (altaz +122:26:41.28 +025:57:12.27)`

After this patch, the following output is returned by targetinfo:
```
# rts2-targetinfo -d 2024-10-21T08:27:14.765UT 776
  776 B 02:17:27.347 +12:03:52.15 +03:59 2.42 +24 21 48.95 121 19 16.35 setting    12006A
```