### PR TITLE
monitor: Fix dms to decimal degrees conversion

### DIFF
--- a/src/monitor/nwindowedit.cpp
+++ b/src/monitor/nwindowedit.cpp
@@ -296,6 +296,7 @@ bool NWindowEditDegrees::passKey (int key)
 
 double NWindowEditDegrees::getValueDouble ()
 {
+	unsigned short neg = 0;
 	char buf[getLength () + 1];
 	char *endptr;
 	mvwinnstr (getWriteWindow (), 0, 0, buf, getLength ());
@@ -303,6 +304,10 @@ double NWindowEditDegrees::getValueDouble ()
 	double tval = 0;
 	while (*p != '\0')
 	{
+		if (*p == '-') {
+			neg = 1;
+			p++;
+		}
 		double v = strtod (p, &endptr);
 		switch (*endptr)
 		{
@@ -320,13 +325,13 @@ double NWindowEditDegrees::getValueDouble ()
 				tval += v / 3600.0;
 				break;
 			default:
-				return tval;
+				return neg ? -tval : tval;
 		}
 		p = endptr;
 		if (*p != '\0')
 			p++;
 	}
-	return tval;
+	return neg ? -tval : tval;
 }
 
 


### PR DESCRIPTION
Actual algorithm does not work properly for negative values.

For example, if we input the value -54'15":
* In the first loop it will set tval to -0.900
* In the second loop it will add .004166 to that value, which is wrong.

This approach uses a variable to control if the value is negative.